### PR TITLE
Cleanup docker database configuration

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,3 +1,0 @@
-FROM postgres:12
-
-COPY ./database/schema.sql ./docker-entrypoint-initdb.d

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,4 +1,0 @@
-CREATE TABLE example_table (
-    created_at timestamp ,
-    id SERIAL PRIMARY KEY
-);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,11 @@ services:
     links:
       - dev-database
   dev-database:
+    image: postgres:12
+    ports:
+      - 5432:5432
     env_file:
       - database.env
-    image: postgres:12
-    volumes:
-      - ./database:/docker-entrypoint-initdb.d
 
   bonuscalc-api-test:
     image: bonuscalc-api-test
@@ -34,10 +34,7 @@ services:
       - test-database
 
   test-database:
-    image: test-database
-    build:
-      context: .
-      dockerfile: database/Dockerfile
+    image: postgres:12
     ports:
       - 5432:5432
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,9 @@ services:
       - 3000:3000
     environment:
       - CONNECTION_STRING=Host=dev-database;Port=5432;Database=testdb;Username=postgres;Password=mypassword
-    links:
+    depends_on:
       - dev-database
+
   dev-database:
     image: postgres:12
     ports:
@@ -30,7 +31,7 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=mypassword
       - DB_DATABASE=testdb
-    links:
+    depends_on:
       - test-database
 
   test-database:


### PR DESCRIPTION
* Removes unnecessary database init config for postgres
* Exposes port 5432 for connecting to the dev database from outside docker
* Updates legacy docker compose `links` config to `depends_on`
