### PR TITLE
Fix inconsistency in RH base url config name

### DIFF
--- a/BonusCalcApi.Tests/V1/Gateways/OperativesGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/OperativesGatewayTests.cs
@@ -35,7 +35,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
             _gatewayOptionsMock.Setup(gwo => gwo.Value)
                 .Returns(new OperativesGatewayOptions
                 {
-                    RepairsHubBaseAddr = "http://null/",
+                    RepairsHubBaseUrl = new Uri("http://null/"),
                     RepairsHubApiKey = "-"
                 });
 

--- a/BonusCalcApi/Program.cs
+++ b/BonusCalcApi/Program.cs
@@ -1,17 +1,17 @@
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace BonusCalcApi
 {
     public static class Program
     {
         public static void Main(string[] args)
-        {
-            CreateWebHostBuilder(args).Build().Run();
-        }
+            => CreateHostBuilder(args).Build().Run();
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+        public static IHostBuilder CreateHostBuilder(string[] args)
+            => Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(
+                    webBuilder => webBuilder.UseStartup<Startup>());
     }
 }

--- a/BonusCalcApi/Startup.cs
+++ b/BonusCalcApi/Startup.cs
@@ -37,7 +37,6 @@ namespace BonusCalcApi
 
         public IConfiguration Configuration { get; }
         private static List<ApiVersionDescription> _apiVersions { get; set; }
-        //TODO update the below to the name of your API
         private const string ApiName = "BonusCalc";
 
         // This method gets called by the runtime. Use this method to add services to the container.
@@ -128,7 +127,7 @@ namespace BonusCalcApi
         {
             var ogo = ConfigureOptions();
 
-            AddClient(services, HttpClientNames.Repairs, new Uri(ogo.RepairsHubBaseAddr, UriKind.Absolute), ogo.RepairsHubApiKey);
+            AddClient(services, HttpClientNames.Repairs, ogo.RepairsHubBaseUrl, ogo.RepairsHubApiKey);
         }
 
         private static void AddClient(IServiceCollection services, string clientName, Uri uri, string key)

--- a/BonusCalcApi/V1/Gateways/OperativesGateway.cs
+++ b/BonusCalcApi/V1/Gateways/OperativesGateway.cs
@@ -27,8 +27,7 @@ namespace BonusCalcApi.V1.Gateways
         {
             _logger.LogInformation($"Starting call to RepairsHub for operative [{payrollNumber}]");
 
-            Uri url = new Uri(_gatewayOptions.RepairsHubBaseAddr, UriKind.Absolute);
-            var response = await _apiGateway.ExecuteRequest<OperativeResponse>(HttpClientNames.Repairs, url).ConfigureAwait(false);
+            var response = await _apiGateway.ExecuteRequest<OperativeResponse>(HttpClientNames.Repairs, _gatewayOptions.RepairsHubBaseUrl).ConfigureAwait(false);
 
             if (response.Status == HttpStatusCode.NotFound)
             {

--- a/BonusCalcApi/V1/Gateways/OperativesGatewayOptions.cs
+++ b/BonusCalcApi/V1/Gateways/OperativesGatewayOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace BonusCalcApi.V1.Gateways
@@ -6,7 +7,7 @@ namespace BonusCalcApi.V1.Gateways
     {
         public const string OpGatewayOptionsName = "OperativesGatewayOptions";
         [Required]
-        public string RepairsHubBaseAddr { get; set; }
+        public Uri RepairsHubBaseUrl { get; set; }
         [Required]
         public string RepairsHubApiKey { get; set; }
     }


### PR DESCRIPTION
In appsettings.json it's `RepairsHubBaseUrl` but the code was using `RepairsHubBaseAddr`.