### PR TITLE
Drop generated identity values for static data

### DIFF
--- a/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
+++ b/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
@@ -43,6 +43,10 @@ namespace BonusCalcApi.V1.Infrastructure
                 .HasForeignKey(o => o.SchemeId);
 
             modelBuilder.Entity<PayBand>()
+                .Property(pb => pb.Id)
+                .ValueGeneratedNever();
+
+            modelBuilder.Entity<PayBand>()
                 .HasIndex(pb => pb.SchemeId);
 
             modelBuilder.Entity<PayBand>()
@@ -104,6 +108,10 @@ namespace BonusCalcApi.V1.Infrastructure
                 .HasDefaultValue(0.0);
 
             modelBuilder.Entity<PayElementType>()
+                .Property(pet => pet.Id)
+                .ValueGeneratedNever();
+
+            modelBuilder.Entity<PayElementType>()
                 .HasIndex(pet => pet.Description)
                 .IsUnique();
 
@@ -114,6 +122,10 @@ namespace BonusCalcApi.V1.Infrastructure
             modelBuilder.Entity<PayElementType>()
                 .Property(pet => pet.Adjustment)
                 .HasDefaultValue(false);
+
+            modelBuilder.Entity<Scheme>()
+                .Property(s => s.Id)
+                .ValueGeneratedNever();
 
             modelBuilder.Entity<Scheme>()
                 .HasIndex(s => s.Description)

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211031101646_DropIdentityFromPayElementTypes.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211031101646_DropIdentityFromPayElementTypes.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211031101646_DropIdentityFromPayElementTypes")]
+    partial class DropIdentityFromPayElementTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -111,8 +113,10 @@ namespace V1.Infrastructure.Migrations
             modelBuilder.Entity("BonusCalcApi.V1.Infrastructure.PayBand", b =>
                 {
                     b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .HasColumnName("id");
+                        .HasColumnName("id")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<int>("Band")
                         .HasColumnType("integer")
@@ -284,8 +288,10 @@ namespace V1.Infrastructure.Migrations
             modelBuilder.Entity("BonusCalcApi.V1.Infrastructure.Scheme", b =>
                 {
                     b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .HasColumnName("id");
+                        .HasColumnName("id")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<decimal>("ConversionFactor")
                         .ValueGeneratedOnAdd()

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211031101646_DropIdentityFromPayElementTypes.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211031101646_DropIdentityFromPayElementTypes.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class DropIdentityFromPayElementTypes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "pay_element_types",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "pay_element_types",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211031102001_DropIdentityFromSchemesAndPayBands.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211031102001_DropIdentityFromSchemesAndPayBands.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211031102001_DropIdentityFromSchemesAndPayBands")]
+    partial class DropIdentityFromSchemesAndPayBands
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211031102001_DropIdentityFromSchemesAndPayBands.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211031102001_DropIdentityFromSchemesAndPayBands.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class DropIdentityFromSchemesAndPayBands : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "schemes",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "pay_bands",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "schemes",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "pay_bands",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+        }
+    }
+}


### PR DESCRIPTION
The pay element types and the pay bands are static data which we'll need to be able to refer from other systems so using generated values doesn't make sense. For example, the listener service will need to know the id for the relevant pay element type to create a productive entry in the pay elements table. I suggest we scope the types into three bandings based on current requirements:

```
1xx: Non-productive types such as dayworks and annual leave
2xx: Adjustments such as manual adjustments and balance brought forward
3xx: Productive types - initially reactive repairs but can be expanded
```

Similarly, the schemes and pay bands once setup should not change so I suggest the following numbering:

```
1: SMV scheme
2: Electrician
3: Plumber
4: Carpenter
5: Glazier
6: Gas Engineer
7: Roofer
8: Legacy SMV
```

The pay band ids will fall naturally then into ranges such as 11-19 for the SMV scheme, 21-29 for the Electrician scheme and so on. Note that not all of the schemes may be in use but these bandings were identified based on all available data including the last 0093.pdf report. In that report it seems that some operatives were on an SMV scheme that had slightly lower values for the bands 2-6 (5% lower, e.g. 140% for band 3 vs. 145% for band 3 reported in other documentation).
