### PR TITLE
Add 'out of hours' and 'overtime' flags

### DIFF
--- a/BonusCalcApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/BonusCalcApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -83,6 +83,8 @@ namespace BonusCalcApi.Tests.V1.Factories
             payElementTypeResponse.Paid.Should().Be(payElementType.Paid);
             payElementTypeResponse.Productive.Should().Be(payElementType.Productive);
             payElementTypeResponse.Adjustment.Should().Be(payElementType.Adjustment);
+            payElementTypeResponse.OutOfHours.Should().Be(payElementType.OutOfHours);
+            payElementTypeResponse.Overtime.Should().Be(payElementType.Overtime);
         }
 
         private static void ValidateWeek(WeekResponse weekResponse, Week week)

--- a/BonusCalcApi.Tests/V1/Gateways/PayElementTypeGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/PayElementTypeGatewayTests.cs
@@ -45,7 +45,9 @@ namespace BonusCalcApi.Tests.V1.Gateways
                     Paid = true,
                     Adjustment = false,
                     Productive = false,
-                    NonProductive = true
+                    NonProductive = true,
+                    OutOfHours = false,
+                    Overtime = false
                 },
                 new PayElementType
                 {
@@ -55,7 +57,9 @@ namespace BonusCalcApi.Tests.V1.Gateways
                     Paid = false,
                     Adjustment = true,
                     Productive = false,
-                    NonProductive = false
+                    NonProductive = false,
+                    OutOfHours = false,
+                    Overtime = false
                 },
                 new PayElementType
                 {
@@ -65,7 +69,9 @@ namespace BonusCalcApi.Tests.V1.Gateways
                     Paid = true,
                     Adjustment = false,
                     Productive = true,
-                    NonProductive = false
+                    NonProductive = false,
+                    OutOfHours = false,
+                    Overtime = false
                 }
             };
 

--- a/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
@@ -181,7 +181,9 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 Paid = true,
                 Adjustment = false,
                 Productive = false,
-                NonProductive = true
+                NonProductive = true,
+                OutOfHours = false,
+                Overtime = false
             };
 
             var productiveType = new PayElementType
@@ -192,7 +194,9 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 Paid = true,
                 Adjustment = false,
                 Productive = true,
-                NonProductive = false
+                NonProductive = false,
+                OutOfHours = false,
+                Overtime = false
             };
 
             var timesheets = new List<Timesheet>()

--- a/BonusCalcApi.Tests/V1/Gateways/TimesheetGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/TimesheetGatewayTests.cs
@@ -117,7 +117,9 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 Paid = true,
                 Adjustment = false,
                 Productive = false,
-                NonProductive = true
+                NonProductive = true,
+                OutOfHours = false,
+                Overtime = false
             };
 
             var timesheet = new Timesheet

--- a/BonusCalcApi/V1/Boundary/Response/PayElementTypeResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/PayElementTypeResponse.cs
@@ -15,5 +15,9 @@ namespace BonusCalcApi.V1.Boundary.Response
         public bool Productive { get; set; }
 
         public bool Adjustment { get; set; }
+
+        public bool OutOfHours { get; set; }
+
+        public bool Overtime { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Factories/ResponseFactory.cs
+++ b/BonusCalcApi/V1/Factories/ResponseFactory.cs
@@ -87,7 +87,9 @@ namespace BonusCalcApi.V1.Factories
                 Paid = payElementType.Paid,
                 NonProductive = payElementType.NonProductive,
                 Productive = payElementType.Productive,
-                Adjustment = payElementType.Adjustment
+                Adjustment = payElementType.Adjustment,
+                OutOfHours = payElementType.OutOfHours,
+                Overtime = payElementType.Overtime
             };
         }
 

--- a/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
+++ b/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
@@ -129,6 +129,14 @@ namespace BonusCalcApi.V1.Infrastructure
                 .Property(pet => pet.Adjustment)
                 .HasDefaultValue(false);
 
+            modelBuilder.Entity<PayElementType>()
+                .Property(pet => pet.OutOfHours)
+                .HasDefaultValue(false);
+
+            modelBuilder.Entity<PayElementType>()
+                .Property(pet => pet.Overtime)
+                .HasDefaultValue(false);
+
             modelBuilder.Entity<Scheme>()
                 .Property(s => s.Id)
                 .ValueGeneratedNever();

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211110064800_AddOutOfHoursAndOvertimeFlags.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211110064800_AddOutOfHoursAndOvertimeFlags.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211110064800_AddOutOfHoursAndOvertimeFlags")]
+    partial class AddOutOfHoursAndOvertimeFlags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211110064800_AddOutOfHoursAndOvertimeFlags.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211110064800_AddOutOfHoursAndOvertimeFlags.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddOutOfHoursAndOvertimeFlags : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "out_of_hours",
+                table: "pay_element_types",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "overtime",
+                table: "pay_element_types",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "out_of_hours",
+                table: "pay_element_types");
+
+            migrationBuilder.DropColumn(
+                name: "overtime",
+                table: "pay_element_types");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/PayElementType.cs
+++ b/BonusCalcApi/V1/Infrastructure/PayElementType.cs
@@ -22,6 +22,10 @@ namespace BonusCalcApi.V1.Infrastructure
 
         public bool Adjustment { get; set; }
 
+        public bool OutOfHours { get; set; }
+
+        public bool Overtime { get; set; }
+
         public List<PayElement> PayElements { get; set; }
     }
 }


### PR DESCRIPTION
We need to be able to discern these pay element types them from other non-productive types to exclude them from bonus calculation as they are paid directly and don't earn SMVs.
