### PR TITLE
Add a selectable flag to pay element types

### DIFF
--- a/BonusCalcApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/BonusCalcApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -85,6 +85,7 @@ namespace BonusCalcApi.Tests.V1.Factories
             payElementTypeResponse.Adjustment.Should().Be(payElementType.Adjustment);
             payElementTypeResponse.OutOfHours.Should().Be(payElementType.OutOfHours);
             payElementTypeResponse.Overtime.Should().Be(payElementType.Overtime);
+            payElementTypeResponse.Selectable.Should().Be(payElementType.Selectable);
         }
 
         private static void ValidateWeek(WeekResponse weekResponse, Week week)

--- a/BonusCalcApi.Tests/V1/Gateways/PayElementTypeGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/PayElementTypeGatewayTests.cs
@@ -47,7 +47,8 @@ namespace BonusCalcApi.Tests.V1.Gateways
                     Productive = false,
                     NonProductive = true,
                     OutOfHours = false,
-                    Overtime = false
+                    Overtime = false,
+                    Selectable = true
                 },
                 new PayElementType
                 {
@@ -56,10 +57,11 @@ namespace BonusCalcApi.Tests.V1.Gateways
                     PayAtBand = false,
                     Paid = false,
                     Adjustment = true,
-                    Productive = false,
+                    Productive = true,
                     NonProductive = false,
                     OutOfHours = false,
-                    Overtime = false
+                    Overtime = false,
+                    Selectable = true
                 },
                 new PayElementType
                 {

--- a/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
@@ -183,7 +183,8 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 Productive = false,
                 NonProductive = true,
                 OutOfHours = false,
-                Overtime = false
+                Overtime = false,
+                Selectable = true
             };
 
             var productiveType = new PayElementType
@@ -196,7 +197,8 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 Productive = true,
                 NonProductive = false,
                 OutOfHours = false,
-                Overtime = false
+                Overtime = false,
+                Selectable = false
             };
 
             var timesheets = new List<Timesheet>()

--- a/BonusCalcApi.Tests/V1/Gateways/TimesheetGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/TimesheetGatewayTests.cs
@@ -119,7 +119,8 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 Productive = false,
                 NonProductive = true,
                 OutOfHours = false,
-                Overtime = false
+                Overtime = false,
+                Selectable = true
             };
 
             var timesheet = new Timesheet

--- a/BonusCalcApi/V1/Boundary/Response/PayElementTypeResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/PayElementTypeResponse.cs
@@ -19,5 +19,7 @@ namespace BonusCalcApi.V1.Boundary.Response
         public bool OutOfHours { get; set; }
 
         public bool Overtime { get; set; }
+
+        public bool Selectable { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Factories/ResponseFactory.cs
+++ b/BonusCalcApi/V1/Factories/ResponseFactory.cs
@@ -89,7 +89,8 @@ namespace BonusCalcApi.V1.Factories
                 Productive = payElementType.Productive,
                 Adjustment = payElementType.Adjustment,
                 OutOfHours = payElementType.OutOfHours,
-                Overtime = payElementType.Overtime
+                Overtime = payElementType.Overtime,
+                Selectable = payElementType.Selectable
             };
         }
 

--- a/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
+++ b/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
@@ -137,6 +137,10 @@ namespace BonusCalcApi.V1.Infrastructure
                 .Property(pet => pet.Overtime)
                 .HasDefaultValue(false);
 
+            modelBuilder.Entity<PayElementType>()
+                .Property(pet => pet.Selectable)
+                .HasDefaultValue(false);
+
             modelBuilder.Entity<Scheme>()
                 .Property(s => s.Id)
                 .ValueGeneratedNever();

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211112171910_AddSelectableFlagToPayElementTypes.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211112171910_AddSelectableFlagToPayElementTypes.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211112171910_AddSelectableFlagToPayElementTypes")]
+    partial class AddSelectableFlagToPayElementTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211112171910_AddSelectableFlagToPayElementTypes.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211112171910_AddSelectableFlagToPayElementTypes.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddSelectableFlagToPayElementTypes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "selectable",
+                table: "pay_element_types",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            // Set initial values for existing non-editable pay element types
+            migrationBuilder.Sql("UPDATE pay_element_types SET selectable = TRUE WHERE id < 200");
+
+            // Ensure adjustable pay element types are marked as productive
+            migrationBuilder.Sql("UPDATE pay_element_types SET productive = TRUE WHERE adjustment = TRUE");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "selectable",
+                table: "pay_element_types");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/PayElementType.cs
+++ b/BonusCalcApi/V1/Infrastructure/PayElementType.cs
@@ -26,6 +26,8 @@ namespace BonusCalcApi.V1.Infrastructure
 
         public bool Overtime { get; set; }
 
+        public bool Selectable { get; set; }
+
         public List<PayElement> PayElements { get; set; }
     }
 }


### PR DESCRIPTION
This is to control what appears in the drop down boxes when pay elements are being edited in the frontend application.

Additionally marking adjustment pay elements as productive so that they appear in the summary reports. This allows us to use the 200-299 range for the 'Productive not in Repairs Hub' feature and keep the 300+ range for productive time coming from Repairs Hub.
