### PR TITLE
Convert timesheet id to a predictable string

### DIFF
--- a/BonusCalcApi.Tests/V1/E2ETests/OperativeTests.cs
+++ b/BonusCalcApi.Tests/V1/E2ETests/OperativeTests.cs
@@ -124,6 +124,7 @@ namespace BonusCalcApi.Tests.V1.E2ETests
             payElement.Duration.Should().Be(expectedPayElement.Duration);
             payElement.Value.Should().Be(expectedPayElement.Value);
             payElement.WorkOrder.Should().Be(expectedPayElement.WorkOrder);
+            payElement.ClosedAt.Should().Be(expectedPayElement.ClosedAt);
         }
 
         private PayElementUpdate CreatePayElementUpdate(IEnumerable<PayElementType> payElementsTypes)

--- a/BonusCalcApi.Tests/V1/Factories/DbFactoryTests.cs
+++ b/BonusCalcApi.Tests/V1/Factories/DbFactoryTests.cs
@@ -40,6 +40,7 @@ namespace BonusCalcApi.Tests.V1.Factories
             result.Duration.Should().Be(payElementUpdate.Duration);
             result.Value.Should().Be(payElementUpdate.Value);
             result.WorkOrder.Should().Be(payElementUpdate.WorkOrder);
+            result.ClosedAt.Should().Be(payElementUpdate.ClosedAt);
             result.PayElementTypeId.Should().Be(payElementUpdate.PayElementTypeId);
         }
     }

--- a/BonusCalcApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/BonusCalcApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -72,6 +72,7 @@ namespace BonusCalcApi.Tests.V1.Factories
             payElementResponse.Duration.Should().Be(payElement.Duration);
             payElementResponse.Value.Should().Be(payElement.Value);
             payElementResponse.WorkOrder.Should().Be(payElement.WorkOrder);
+            payElementResponse.ClosedAt.Should().Be(payElement.ClosedAt);
             ValidatePayElementType(payElementResponse.PayElementType, payElement.PayElementType);
         }
 

--- a/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
@@ -258,8 +258,10 @@ namespace BonusCalcApi.Tests.V1.Gateways
                             WorkOrder = "1000001",
                             Address = "1 Knowhere Road",
                             Comment = "Fix broken light switch",
+                            Tuesday = 100.0M,
                             Value = 100.0M,
-                            ReadOnly = true
+                            ReadOnly = true,
+                            ClosedAt = new DateTime(2021, 8, 17, 14, 0, 0, DateTimeKind.Utc)
                         }
                     }
                 }

--- a/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
@@ -205,6 +205,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
             {
                 new Timesheet
                 {
+                    Id = "123456/2021-08-02",
                     WeekId = "2021-08-02",
                     Operative = operative,
                     PayElements = new List<PayElement>()
@@ -225,6 +226,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 },
                 new Timesheet
                 {
+                    Id = "123456/2021-08-09",
                     WeekId = "2021-08-09",
                     Operative = operative,
                     PayElements = new List<PayElement>()
@@ -245,6 +247,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 },
                 new Timesheet
                 {
+                    Id = "123456/2021-08-16",
                     WeekId = "2021-08-16",
                     Operative = operative,
                     PayElements = new List<PayElement>()

--- a/BonusCalcApi.Tests/V1/Gateways/TimesheetGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/TimesheetGatewayTests.cs
@@ -125,6 +125,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
 
             var timesheet = new Timesheet
             {
+                Id = "123456/2021-10-18",
                 Week = week,
                 Operative = operative,
                 PayElements = new List<PayElement>()

--- a/BonusCalcApi/V1/Boundary/Request/PayElementUpdate.cs
+++ b/BonusCalcApi/V1/Boundary/Request/PayElementUpdate.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace BonusCalcApi.V1.Boundary.Request
 {
     public class PayElementUpdate
@@ -23,5 +25,7 @@ namespace BonusCalcApi.V1.Boundary.Request
         public decimal Duration { get; set; }
 
         public decimal Value { get; set; }
+
+        public DateTime? ClosedAt { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Boundary/Request/TimesheetUpdate.cs
+++ b/BonusCalcApi/V1/Boundary/Request/TimesheetUpdate.cs
@@ -4,7 +4,7 @@ namespace BonusCalcApi.V1.Boundary.Request
 {
     public class TimesheetUpdateRequest
     {
-        public int Id { get; set; }
+        public string Id { get; set; }
         public List<PayElementUpdate> PayElements { get; set; }
     }
 

--- a/BonusCalcApi/V1/Boundary/Response/PayElementResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/PayElementResponse.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace BonusCalcApi.V1.Boundary.Response
 {
     public class PayElementResponse
@@ -25,5 +27,7 @@ namespace BonusCalcApi.V1.Boundary.Response
         public decimal Duration { get; set; }
 
         public decimal Value { get; set; }
+
+        public DateTime? ClosedAt { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Boundary/Response/TimesheetResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/TimesheetResponse.cs
@@ -4,7 +4,7 @@ namespace BonusCalcApi.V1.Boundary.Response
 {
     public class TimesheetResponse
     {
-        public int Id { get; set; }
+        public string Id { get; set; }
         public WeekResponse Week { get; set; }
         public List<PayElementResponse> PayElements { get; set; }
     }

--- a/BonusCalcApi/V1/Factories/DbFactory.cs
+++ b/BonusCalcApi/V1/Factories/DbFactory.cs
@@ -22,6 +22,7 @@ namespace BonusCalcApi.V1.Factories
                 Duration = payElementUpdate.Duration,
                 Value = payElementUpdate.Value,
                 WorkOrder = payElementUpdate.WorkOrder,
+                ClosedAt = payElementUpdate.ClosedAt,
                 PayElementTypeId = payElementUpdate.PayElementTypeId
             };
         }

--- a/BonusCalcApi/V1/Factories/ResponseFactory.cs
+++ b/BonusCalcApi/V1/Factories/ResponseFactory.cs
@@ -73,6 +73,7 @@ namespace BonusCalcApi.V1.Factories
                 Duration = payElement.Duration,
                 Value = payElement.Value,
                 WorkOrder = payElement.WorkOrder,
+                ClosedAt = payElement.ClosedAt,
                 PayElementType = payElement.PayElementType.ToResponse()
             };
         }

--- a/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
+++ b/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
@@ -32,6 +32,9 @@ namespace BonusCalcApi.V1.Infrastructure
                 .IsUnique();
 
             modelBuilder.Entity<Operative>()
+                .HasIndex(o => o.TradeId);
+
+            modelBuilder.Entity<Operative>()
                 .HasOne(o => o.Trade)
                 .WithMany(t => t.Operatives)
                 .HasForeignKey(o => o.TradeId);
@@ -57,9 +60,15 @@ namespace BonusCalcApi.V1.Infrastructure
                 .HasForeignKey(pb => pb.SchemeId);
 
             modelBuilder.Entity<PayElement>()
+                .HasIndex(pe => pe.TimesheetId);
+
+            modelBuilder.Entity<PayElement>()
                 .HasOne(pe => pe.Timesheet)
                 .WithMany(t => t.PayElements)
                 .HasForeignKey(t => t.TimesheetId);
+
+            modelBuilder.Entity<PayElement>()
+                .HasIndex(pe => pe.PayElementTypeId);
 
             modelBuilder.Entity<PayElement>()
                 .HasOne(pe => pe.PayElementType)
@@ -155,8 +164,15 @@ namespace BonusCalcApi.V1.Infrastructure
                 .HasDefaultValue(1.0);
 
             modelBuilder.Entity<Timesheet>()
+                .Property(t => t.Id)
+                .ValueGeneratedNever();
+
+            modelBuilder.Entity<Timesheet>()
                 .HasIndex(t => new { t.OperativeId, t.WeekId })
                 .IsUnique();
+
+            modelBuilder.Entity<Timesheet>()
+                .HasIndex(t => t.WeekId);
 
             modelBuilder.Entity<Timesheet>()
                 .HasOne(t => t.Operative)

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211115174026_ConvertTimesheetIdToString.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211115174026_ConvertTimesheetIdToString.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211115174026_ConvertTimesheetIdToString")]
+    partial class ConvertTimesheetIdToString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211115174026_ConvertTimesheetIdToString.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211115174026_ConvertTimesheetIdToString.cs
@@ -1,0 +1,315 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class ConvertTimesheetIdToString : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "new_id",
+                table: "timesheets",
+                type: "character varying(17)",
+                maxLength: 17,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "new_timesheet_id",
+                table: "pay_elements",
+                type: "character varying(17)",
+                maxLength: 17,
+                nullable: true);
+
+            migrationBuilder.Sql(@"
+                UPDATE timesheets
+                SET new_id = CONCAT(operative_id, '/', week_id)
+            ");
+
+            migrationBuilder.Sql(@"
+                UPDATE pay_elements AS p
+                SET new_timesheet_id = t.new_id
+                FROM timesheets AS t
+                WHERE p.timesheet_id = t.id
+            ");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "new_id",
+                table: "timesheets",
+                type: "character varying(17)",
+                maxLength: 17,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(17)",
+                oldMaxLength: 17,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "new_timesheet_id",
+                table: "pay_elements",
+                type: "character varying(17)",
+                maxLength: 17,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(17)",
+                oldMaxLength: 17,
+                oldNullable: true);
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_pay_elements_timesheets_timesheet_id",
+                table: "pay_elements");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_timesheets",
+                table: "timesheets");
+
+            migrationBuilder.Sql("DROP VIEW weekly_summaries");
+            migrationBuilder.Sql("DROP VIEW productive_pay_elements");
+            migrationBuilder.Sql("DROP VIEW non_productive_pay_elements");
+
+            migrationBuilder.DropColumn(
+                name: "id",
+                table: "timesheets");
+
+            migrationBuilder.DropColumn(
+                name: "timesheet_id",
+                table: "pay_elements");
+
+            migrationBuilder.RenameColumn(
+                name: "new_timesheet_id",
+                table: "pay_elements",
+                newName: "timesheet_id");
+
+            migrationBuilder.RenameColumn(
+                name: "new_id",
+                table: "timesheets",
+                newName: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_timesheets",
+                table: "timesheets",
+                column: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_pay_elements_timesheets_timesheet_id",
+                table: "pay_elements",
+                column: "timesheet_id",
+                principalTable: "timesheets",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.Sql(@"
+CREATE VIEW productive_pay_elements AS
+SELECT
+    p.timesheet_id,
+    SUM(p.value)::numeric(10,4) AS value
+FROM
+    pay_elements AS p
+INNER JOIN
+    pay_element_types AS t
+ON
+    p.pay_element_type_id = t.id
+WHERE
+    t.productive = TRUE
+GROUP BY
+    p.timesheet_id
+            ");
+
+            migrationBuilder.Sql(@"
+CREATE VIEW non_productive_pay_elements AS
+SELECT
+    p.timesheet_id,
+    SUM(p.duration)::numeric(10,4) AS duration,
+    SUM(p.value)::numeric(10,4) AS value
+FROM
+    pay_elements AS p
+INNER JOIN
+    pay_element_types AS t
+ON
+    p.pay_element_type_id = t.id
+WHERE
+    t.non_productive = TRUE
+GROUP BY
+    p.timesheet_id
+            ");
+
+            migrationBuilder.Sql(@"
+CREATE VIEW weekly_summaries AS
+SELECT
+    CONCAT(t.operative_id, '/', w.bonus_period_id, '/', w.id) AS id,
+    CONCAT(t.operative_id, '/', w.bonus_period_id) AS summary_id,
+	w.number,
+	w.start_at,
+	w.closed_at,
+	COALESCE(p.value, 0)::numeric(10,4) AS productive_value,
+	COALESCE(np.duration, 0)::numeric(10,4) AS non_productive_duration,
+	COALESCE(np.value, 0)::numeric(10,4) AS non_productive_value,
+	(COALESCE(p.value, 0) + COALESCE(np.value, 0))::numeric(10,4) AS total_value,
+	ROUND(
+        AVG(COALESCE(p.value, 0) + COALESCE(np.value, 0))
+        OVER (
+            PARTITION BY w.bonus_period_id, t.operative_id
+            ORDER BY w.number ASC
+    ), 4)::numeric(10,4) AS projected_value
+FROM
+    weeks AS w
+INNER JOIN
+    timesheets AS t
+ON
+    w.id = t.week_id
+LEFT JOIN
+    productive_pay_elements AS p
+ON
+    t.id = p.timesheet_id
+LEFT JOIN
+    non_productive_pay_elements AS np
+ON t.id = np.timesheet_id
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "old_id",
+                table: "timesheets",
+                type: "integer",
+                nullable: false)
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddColumn<int>(
+                name: "old_timesheet_id",
+                table: "pay_elements",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.Sql(@"
+                UPDATE pay_elements AS p
+                SET old_timesheet_id = t.old_id
+                FROM timesheets AS t
+                WHERE p.timesheet_id = t.id
+            ");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "pay_element_types",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_pay_elements_timesheets_timesheet_id",
+                table: "pay_elements");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_timesheets",
+                table: "timesheets");
+
+            migrationBuilder.Sql("DROP VIEW weekly_summaries");
+            migrationBuilder.Sql("DROP VIEW productive_pay_elements");
+            migrationBuilder.Sql("DROP VIEW non_productive_pay_elements");
+
+            migrationBuilder.DropColumn(
+                name: "id",
+                table: "timesheets");
+
+            migrationBuilder.DropColumn(
+                name: "timesheet_id",
+                table: "pay_elements");
+
+            migrationBuilder.RenameColumn(
+                name: "old_timesheet_id",
+                table: "pay_elements",
+                newName: "timesheet_id");
+
+            migrationBuilder.RenameColumn(
+                name: "old_id",
+                table: "timesheets",
+                newName: "id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_timesheets",
+                table: "timesheets",
+                column: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_pay_elements_timesheets_timesheet_id",
+                table: "pay_elements",
+                column: "timesheet_id",
+                principalTable: "timesheets",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.Sql(@"
+CREATE VIEW productive_pay_elements AS
+SELECT
+    p.timesheet_id,
+    SUM(p.value)::numeric(10,4) AS value
+FROM
+    pay_elements AS p
+INNER JOIN
+    pay_element_types AS t
+ON
+    p.pay_element_type_id = t.id
+WHERE
+    t.productive = TRUE
+GROUP BY
+    p.timesheet_id
+            ");
+
+            migrationBuilder.Sql(@"
+CREATE VIEW non_productive_pay_elements AS
+SELECT
+    p.timesheet_id,
+    SUM(p.duration)::numeric(10,4) AS duration,
+    SUM(p.value)::numeric(10,4) AS value
+FROM
+    pay_elements AS p
+INNER JOIN
+    pay_element_types AS t
+ON
+    p.pay_element_type_id = t.id
+WHERE
+    t.non_productive = TRUE
+GROUP BY
+    p.timesheet_id
+            ");
+
+            migrationBuilder.Sql(@"
+CREATE VIEW weekly_summaries AS
+SELECT
+    CONCAT(t.operative_id, '/', w.bonus_period_id, '/', w.id) AS id,
+    CONCAT(t.operative_id, '/', w.bonus_period_id) AS summary_id,
+	w.number,
+	w.start_at,
+	w.closed_at,
+	COALESCE(p.value, 0)::numeric(10,4) AS productive_value,
+	COALESCE(np.duration, 0)::numeric(10,4) AS non_productive_duration,
+	COALESCE(np.value, 0)::numeric(10,4) AS non_productive_value,
+	(COALESCE(p.value, 0) + COALESCE(np.value, 0))::numeric(10,4) AS total_value,
+	ROUND(
+        AVG(COALESCE(p.value, 0) + COALESCE(np.value, 0))
+        OVER (
+            PARTITION BY w.bonus_period_id, t.operative_id
+            ORDER BY w.number ASC
+    ), 4)::numeric(10,4) AS projected_value
+FROM
+    weeks AS w
+INNER JOIN
+    timesheets AS t
+ON
+    w.id = t.week_id
+LEFT JOIN
+    productive_pay_elements AS p
+ON
+    t.id = p.timesheet_id
+LEFT JOIN
+    non_productive_pay_elements AS np
+ON t.id = np.timesheet_id
+            ");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211115191148_AddMissingIndexes.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211115191148_AddMissingIndexes.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211115191148_AddMissingIndexes")]
+    partial class AddMissingIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211115191148_AddMissingIndexes.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211115191148_AddMissingIndexes.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddMissingIndexes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_pay_elements_timesheet_id",
+                table: "pay_elements",
+                column: "timesheet_id");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "timesheet_id",
+                table: "pay_elements",
+                defaultValue: null,
+                oldDefaultValue: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "id",
+                table: "timesheets",
+                defaultValue: null,
+                oldDefaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "id",
+                table: "timesheets",
+                defaultValue: "",
+                oldDefaultValue: null);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "timesheet_id",
+                table: "pay_elements",
+                defaultValue: "",
+                oldDefaultValue: null);
+
+            migrationBuilder.DropIndex(
+                name: "ix_pay_elements_timesheet_id");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211117115451_AddClosedAtToPayElements.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211117115451_AddClosedAtToPayElements.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211117115451_AddClosedAtToPayElements")]
+    partial class AddClosedAtToPayElements
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211117115451_AddClosedAtToPayElements.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211117115451_AddClosedAtToPayElements.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddClosedAtToPayElements : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "closed_at",
+                table: "pay_elements",
+                type: "timestamp without time zone",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "closed_at",
+                table: "pay_elements");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/PayElement.cs
+++ b/BonusCalcApi/V1/Infrastructure/PayElement.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using BonusCalcApi.V1.Boundary.Request;
 
@@ -35,6 +36,7 @@ namespace BonusCalcApi.V1.Infrastructure
 
         public decimal Value { get; set; }
         public bool ReadOnly { get; set; }
+        public DateTime? ClosedAt { get; set; }
 
         public void UpdateFrom(PayElementUpdate payElement)
         {
@@ -51,6 +53,7 @@ namespace BonusCalcApi.V1.Infrastructure
             Value = payElement.Value;
             WorkOrder = payElement.WorkOrder;
             PayElementTypeId = payElement.PayElementTypeId;
+            ClosedAt = payElement.ClosedAt;
         }
     }
 }

--- a/BonusCalcApi/V1/Infrastructure/PayElement.cs
+++ b/BonusCalcApi/V1/Infrastructure/PayElement.cs
@@ -8,7 +8,9 @@ namespace BonusCalcApi.V1.Infrastructure
         [Key]
         public int Id { get; set; }
 
-        public int TimesheetId { get; set; }
+        [Required]
+        [StringLength(17)]
+        public string TimesheetId { get; set; }
         public Timesheet Timesheet { get; set; }
 
         public int PayElementTypeId { get; set; }

--- a/BonusCalcApi/V1/Infrastructure/Timesheet.cs
+++ b/BonusCalcApi/V1/Infrastructure/Timesheet.cs
@@ -7,7 +7,8 @@ namespace BonusCalcApi.V1.Infrastructure
     public class Timesheet
     {
         [Key]
-        public int Id { get; set; }
+        [StringLength(17)]
+        public string Id { get; set; }
 
         [Required]
         [StringLength(6)]


### PR DESCRIPTION
When importing data from Repairs Hub having to know the timesheet id to insert into pay elements adds overhead and makes it more difficult to reason with. By using a concatenation of operative id and week we can eliminate this.

@Asura5 this is a suggestion - when I was importing the data this morning I had to create a VLOOKUP column in Excel to a second sheet with the list of timesheet ids by operative id and being able to just do `123456/2021-01-11` would've saved a lot of effort. Also when viewing the pay elements table it's easier to see when a pay element is from as opposed to just a numeric id. On the downside it'll mean some work on LBHackney-IT/bonuscalc-listener#13 so I can understand if you'd prefer not to.