### PR TITLE
Add utilisation to operative endpoint

### DIFF
--- a/BonusCalcApi.Tests/V1/Gateways/OperativeGatewayTest.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/OperativeGatewayTest.cs
@@ -66,6 +66,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 Scheme = scheme,
                 Section = "H3007",
                 SalaryBand = 5,
+                Utilisation = 1.0M,
                 FixedBand = false,
                 IsArchived = false
             };

--- a/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
@@ -119,6 +119,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 Scheme = scheme,
                 Section = "H3007",
                 SalaryBand = 5,
+                Utilisation = 1.0M,
                 FixedBand = false,
                 IsArchived = false
             };

--- a/BonusCalcApi.Tests/V1/Gateways/TimesheetGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/TimesheetGatewayTests.cs
@@ -69,6 +69,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                 Scheme = scheme,
                 Section = "H3007",
                 SalaryBand = 5,
+                Utilisation = 1.0M,
                 FixedBand = false,
                 IsArchived = false
             };

--- a/BonusCalcApi.Tests/V1/Helpers/FixtureHelpers.cs
+++ b/BonusCalcApi.Tests/V1/Helpers/FixtureHelpers.cs
@@ -24,6 +24,7 @@ namespace BonusCalcApi.Tests.V1.Helpers
         {
             return Fixture.Build<Operative>()
                 .With(o => o.Id, CreateOperativeId())
+                .With(o => o.Utilisation, 1.0M)
                 .Without(o => o.Timesheets);
         }
 

--- a/BonusCalcApi/V1/Boundary/Response/OperativeResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/OperativeResponse.cs
@@ -11,6 +11,7 @@ namespace BonusCalcApi.V1.Boundary.Response
         public SchemeResponse Scheme { get; set; }
         public string Section { get; set; }
         public int SalaryBand { get; set; }
+        public decimal Utilisation { get; set; }
         public bool FixedBand { get; set; }
         public bool IsArchived { get; set; }
     }

--- a/BonusCalcApi/V1/Factories/ResponseFactory.cs
+++ b/BonusCalcApi/V1/Factories/ResponseFactory.cs
@@ -18,6 +18,7 @@ namespace BonusCalcApi.V1.Factories
                 Scheme = operative.Scheme?.ToResponse(),
                 Section = operative.Section,
                 SalaryBand = operative.SalaryBand,
+                Utilisation = operative.Utilisation,
                 FixedBand = operative.FixedBand,
                 IsArchived = operative.IsArchived
             };

--- a/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
+++ b/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
@@ -51,6 +51,11 @@ namespace BonusCalcApi.V1.Infrastructure
                 .HasIndex(o => o.EmailAddress)
                 .IsUnique();
 
+            modelBuilder.Entity<Operative>()
+                .Property(o => o.Utilisation)
+                .HasPrecision(5, 4)
+                .HasDefaultValue(1.0);
+
             modelBuilder.Entity<PayBand>()
                 .Property(pb => pb.Id)
                 .ValueGeneratedNever();

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211123165638_AddUtilisationToOperatives.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211123165638_AddUtilisationToOperatives.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211123165638_AddUtilisationToOperatives")]
+    partial class AddUtilisationToOperatives
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211123165638_AddUtilisationToOperatives.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211123165638_AddUtilisationToOperatives.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddUtilisationToOperatives : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "utilisation",
+                table: "operatives",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: false,
+                defaultValue: 1m);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "utilisation",
+                table: "operatives");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Operative.cs
+++ b/BonusCalcApi/V1/Infrastructure/Operative.cs
@@ -30,6 +30,8 @@ namespace BonusCalcApi.V1.Infrastructure
 
         public int SalaryBand { get; set; }
 
+        public decimal Utilisation { get; set; }
+
         public bool FixedBand { get; set; }
 
         public bool IsArchived { get; set; }


### PR DESCRIPTION
This allows the frontend to adjust the pay bands to compensate for operatives that are employed on a part-time basis.
