### PR TITLE
Add utilisation to timesheet and weekly summaries

### DIFF
--- a/BonusCalcApi.Tests/V1/E2ETests/OperativeTests.cs
+++ b/BonusCalcApi.Tests/V1/E2ETests/OperativeTests.cs
@@ -147,6 +147,7 @@ namespace BonusCalcApi.Tests.V1.E2ETests
             await Context.Weeks.AddAsync(week);
 
             var timesheet = _fixture.Build<Timesheet>()
+                .With(t => t.Utilisation, 1.0M)
                 .With(t => t.OperativeId, operative.Id)
                 .Without(t => t.Operative)
                 .With(t => t.WeekId, week.Id)
@@ -179,6 +180,7 @@ namespace BonusCalcApi.Tests.V1.E2ETests
             }
 
             var timesheet = _fixture.Build<Timesheet>()
+                .With(t => t.Utilisation, 1.0M)
                 .With(t => t.OperativeId, operative.Id)
                 .Without(t => t.Operative)
                 .With(t => t.WeekId, week.Id)

--- a/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/SummaryGatewayTests.cs
@@ -46,7 +46,9 @@ namespace BonusCalcApi.Tests.V1.Gateways
                         NonProductiveDuration = 5.0M,
                         NonProductiveValue = 500.0M,
                         TotalValue = 500.0M,
-                        ProjectedValue = 500.0M
+                        Utilisation = 1.0M,
+                        ProjectedValue = 500.0M,
+                        AverageUtilisation = 1.0M
                     },
                     new WeeklySummary
                     {
@@ -59,7 +61,9 @@ namespace BonusCalcApi.Tests.V1.Gateways
                         NonProductiveDuration = 3.0M,
                         NonProductiveValue = 300.0M,
                         TotalValue = 300.0M,
-                        ProjectedValue = 400.0M
+                        Utilisation = 1.0M,
+                        ProjectedValue = 400.0M,
+                        AverageUtilisation = 1.0M
                     },
                     new WeeklySummary
                     {
@@ -72,7 +76,9 @@ namespace BonusCalcApi.Tests.V1.Gateways
                         NonProductiveDuration = 0.0M,
                         NonProductiveValue = 0.0M,
                         TotalValue = 100.0M,
-                        ProjectedValue = 300.0M
+                        Utilisation = 1.0M,
+                        ProjectedValue = 300.0M,
+                        AverageUtilisation = 1.0M
                     }
                 }
             };
@@ -210,6 +216,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                     Id = "123456/2021-08-02",
                     WeekId = "2021-08-02",
                     Operative = operative,
+                    Utilisation = 1.0M,
                     PayElements = new List<PayElement>()
                     {
                         new PayElement
@@ -231,6 +238,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                     Id = "123456/2021-08-09",
                     WeekId = "2021-08-09",
                     Operative = operative,
+                    Utilisation = 1.0M,
                     PayElements = new List<PayElement>()
                     {
                         new PayElement
@@ -252,6 +260,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                     Id = "123456/2021-08-16",
                     WeekId = "2021-08-16",
                     Operative = operative,
+                    Utilisation = 1.0M,
                     PayElements = new List<PayElement>()
                     {
                         new PayElement

--- a/BonusCalcApi.Tests/V1/UseCase/UpdateTimesheetUseCaseTests.cs
+++ b/BonusCalcApi.Tests/V1/UseCase/UpdateTimesheetUseCaseTests.cs
@@ -221,6 +221,7 @@ namespace BonusCalcApi.Tests.V1.UseCase
         private Timesheet CreateExistingTimesheet()
         {
             var existingTimesheet = _fixture.Build<Timesheet>()
+                .With(t => t.Utilisation, 1.0M)
                 .Without(t => t.PayElements)
                 .Create();
             _timesheetGatewayMock.Setup(x => x.GetOperativeTimesheetAsync(existingTimesheet.OperativeId, existingTimesheet.WeekId))

--- a/BonusCalcApi/V1/Boundary/Response/TimesheetResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/TimesheetResponse.cs
@@ -5,6 +5,7 @@ namespace BonusCalcApi.V1.Boundary.Response
     public class TimesheetResponse
     {
         public string Id { get; set; }
+        public decimal Utilisation { get; set; }
         public WeekResponse Week { get; set; }
         public List<PayElementResponse> PayElements { get; set; }
     }

--- a/BonusCalcApi/V1/Boundary/Response/WeeklySummaryResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/WeeklySummaryResponse.cs
@@ -18,6 +18,10 @@ namespace BonusCalcApi.V1.Boundary.Response
 
         public decimal TotalValue { get; set; }
 
+        public decimal Utilisation { get; set; }
+
         public decimal ProjectedValue { get; set; }
+
+        public decimal AverageUtilisation { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Factories/ResponseFactory.cs
+++ b/BonusCalcApi/V1/Factories/ResponseFactory.cs
@@ -29,6 +29,7 @@ namespace BonusCalcApi.V1.Factories
             return new TimesheetResponse
             {
                 Id = timesheet.Id,
+                Utilisation = timesheet.Utilisation,
                 Week = timesheet.Week.ToResponse(),
                 PayElements = timesheet.PayElements.Select(pe => pe.ToResponse()).OrderBy(pe => pe.Id).ToList()
             };
@@ -147,7 +148,9 @@ namespace BonusCalcApi.V1.Factories
                 NonProductiveDuration = weeklySummary.NonProductiveDuration,
                 NonProductiveValue = weeklySummary.NonProductiveValue,
                 TotalValue = weeklySummary.TotalValue,
-                ProjectedValue = weeklySummary.ProjectedValue
+                Utilisation = weeklySummary.Utilisation,
+                ProjectedValue = weeklySummary.ProjectedValue,
+                AverageUtilisation = weeklySummary.AverageUtilisation
             };
         }
     }

--- a/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
+++ b/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
@@ -193,6 +193,11 @@ namespace BonusCalcApi.V1.Infrastructure
                 .WithMany(w => w.Timesheets)
                 .HasForeignKey(t => t.WeekId);
 
+            modelBuilder.Entity<Timesheet>()
+                .Property(t => t.Utilisation)
+                .HasPrecision(5, 4)
+                .HasDefaultValue(1.0);
+
             modelBuilder.Entity<Trade>()
                 .HasIndex(t => t.Description)
                 .IsUnique();

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211123182708_AddUtilisationToTimesheets.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211123182708_AddUtilisationToTimesheets.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211123182708_AddUtilisationToTimesheets")]
+    partial class AddUtilisationToTimesheets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211123182708_AddUtilisationToTimesheets.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211123182708_AddUtilisationToTimesheets.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddUtilisationToTimesheets : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "utilisation",
+                table: "timesheets",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: false,
+                defaultValue: 1m);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "utilisation",
+                table: "timesheets");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211123184300_AddUtilisationToWeeklySummaries.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211123184300_AddUtilisationToWeeklySummaries.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211123184300_AddUtilisationToWeeklySummaries")]
+    partial class AddUtilisationToWeeklySummaries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211123184300_AddUtilisationToWeeklySummaries.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211123184300_AddUtilisationToWeeklySummaries.cs
@@ -1,0 +1,90 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddUtilisationToWeeklySummaries : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP VIEW weekly_summaries");
+
+            migrationBuilder.Sql(@"
+CREATE VIEW weekly_summaries AS
+SELECT
+    CONCAT(t.operative_id, '/', w.bonus_period_id, '/', w.id) AS id,
+    CONCAT(t.operative_id, '/', w.bonus_period_id) AS summary_id,
+	w.number,
+	w.start_at,
+	w.closed_at,
+	COALESCE(p.value, 0)::numeric(10,4) AS productive_value,
+	COALESCE(np.duration, 0)::numeric(10,4) AS non_productive_duration,
+	COALESCE(np.value, 0)::numeric(10,4) AS non_productive_value,
+	(COALESCE(p.value, 0) + COALESCE(np.value, 0))::numeric(10,4) AS total_value,
+	t.utilisation,
+	ROUND(
+        AVG(COALESCE(p.value, 0) + COALESCE(np.value, 0))
+        OVER (
+            PARTITION BY w.bonus_period_id, t.operative_id
+            ORDER BY w.number ASC
+    ), 4)::numeric(10,4) AS projected_value,
+    ROUND(
+        AVG(t.utilisation)
+        OVER (
+            PARTITION BY w.bonus_period_id, t.operative_id
+            ORDER BY w.number ASC
+    ), 4)::numeric(5,4) AS average_utilisation
+FROM
+    weeks AS w
+INNER JOIN
+    timesheets AS t
+ON
+    w.id = t.week_id
+LEFT JOIN
+    productive_pay_elements AS p
+ON
+    t.id = p.timesheet_id
+LEFT JOIN
+    non_productive_pay_elements AS np
+ON t.id = np.timesheet_id
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP VIEW weekly_summaries");
+
+            migrationBuilder.Sql(@"
+CREATE VIEW weekly_summaries AS
+SELECT
+    CONCAT(t.operative_id, '/', w.bonus_period_id, '/', w.id) AS id,
+    CONCAT(t.operative_id, '/', w.bonus_period_id) AS summary_id,
+	w.number,
+	w.start_at,
+	w.closed_at,
+	COALESCE(p.value, 0)::numeric(10,4) AS productive_value,
+	COALESCE(np.duration, 0)::numeric(10,4) AS non_productive_duration,
+	COALESCE(np.value, 0)::numeric(10,4) AS non_productive_value,
+	(COALESCE(p.value, 0) + COALESCE(np.value, 0))::numeric(10,4) AS total_value,
+	ROUND(
+        AVG(COALESCE(p.value, 0) + COALESCE(np.value, 0))
+        OVER (
+            PARTITION BY w.bonus_period_id, t.operative_id
+            ORDER BY w.number ASC
+    ), 4)::numeric(10,4) AS projected_value
+FROM
+    weeks AS w
+INNER JOIN
+    timesheets AS t
+ON
+    w.id = t.week_id
+LEFT JOIN
+    productive_pay_elements AS p
+ON
+    t.id = p.timesheet_id
+LEFT JOIN
+    non_productive_pay_elements AS np
+ON t.id = np.timesheet_id
+            ");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Timesheet.cs
+++ b/BonusCalcApi/V1/Infrastructure/Timesheet.cs
@@ -18,6 +18,8 @@ namespace BonusCalcApi.V1.Infrastructure
         public string WeekId { get; set; }
         public Week Week { get; set; }
 
+        public decimal Utilisation { get; set; }
+
         public List<PayElement> PayElements { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Infrastructure/WeeklySummary.cs
+++ b/BonusCalcApi/V1/Infrastructure/WeeklySummary.cs
@@ -24,6 +24,10 @@ namespace BonusCalcApi.V1.Infrastructure
 
         public decimal TotalValue { get; set; }
 
+        public decimal Utilisation { get; set; }
+
         public decimal ProjectedValue { get; set; }
+
+        public decimal AverageUtilisation { get; set; }
     }
 }


### PR DESCRIPTION
An operative may change from full-time to part-time or vice-versa during a bonus period so we need to track the utilisation week by week and then use an average utilisation over the whole period to work out the band.
