### PR TITLE
Include utilisation properties in the model snapshot

### DIFF
--- a/BonusCalcApi/V1/Infrastructure/Migrations/BonusCalcContextModelSnapshot.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/BonusCalcContextModelSnapshot.cs
@@ -487,6 +487,10 @@ namespace V1.Infrastructure.Migrations
                         .HasColumnType("text")
                         .HasColumnName("id");
 
+                    b.Property<decimal>("AverageUtilisation")
+                        .HasColumnType("numeric")
+                        .HasColumnName("average_utilisation");
+
                     b.Property<DateTime?>("ClosedAt")
                         .HasColumnType("timestamp without time zone")
                         .HasColumnName("closed_at");
@@ -522,6 +526,10 @@ namespace V1.Infrastructure.Migrations
                     b.Property<decimal>("TotalValue")
                         .HasColumnType("numeric")
                         .HasColumnName("total_value");
+
+                    b.Property<decimal>("Utilisation")
+                        .HasColumnType("numeric")
+                        .HasColumnName("utilisation");
 
                     b.HasKey("Id")
                         .HasName("pk_weekly_summaries");


### PR DESCRIPTION
These were missed off LBHackney-IT/bonuscalc-api#48 because EF would try to create a migration to insert the columns into the view - the workaround is to create a dummy migration afterwards to pick up the new properties on the view-backed models.
