### PR TITLE
Add search endpoints for pay elements and operatives

### DIFF
--- a/BonusCalcApi.Tests/V1/Controllers/WorkElementsControllerTests.cs
+++ b/BonusCalcApi.Tests/V1/Controllers/WorkElementsControllerTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using AutoFixture;
+using BonusCalcApi.Tests.V1.Controllers.Mocks;
+using BonusCalcApi.Tests.V1.Helpers.Mocks;
+using BonusCalcApi.V1.Boundary.Request;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using BonusCalcApi.V1.Boundary.Response;
+using BonusCalcApi.V1.Controllers;
+using BonusCalcApi.V1.Controllers.Helpers;
+using BonusCalcApi.V1.Factories;
+using BonusCalcApi.V1.Infrastructure;
+using BonusCalcApi.V1.UseCase.Interfaces;
+
+namespace BonusCalcApi.Tests.V1.Controllers
+{
+    [TestFixture]
+    public class WorkElementsControllerTests : ControllerTests
+    {
+        private readonly Fixture _fixture = new Fixture();
+
+        private Mock<IGetWorkElementsUseCase> _getWorkElementsUseCaseMock;
+        private MockProblemDetailsFactory _problemDetailsFactoryMock;
+
+        private WorkElementsController _classUnderTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+            _getWorkElementsUseCaseMock = new Mock<IGetWorkElementsUseCase>();
+            _problemDetailsFactoryMock = new MockProblemDetailsFactory();
+
+            _classUnderTest = new WorkElementsController(
+                _getWorkElementsUseCaseMock.Object
+            );
+
+            // .NET 3.1 doesn't set ProblemDetailsFactory so we need to mock it
+            _classUnderTest.ProblemDetailsFactory = _problemDetailsFactoryMock.Object;
+        }
+
+        [Test]
+        public async Task GetWorkElementsReturnsOk()
+        {
+            // Arrange
+            var expectedWorkElements = _fixture.CreateMany<WorkElement>();
+            _getWorkElementsUseCaseMock
+                .Setup(m => m.ExecuteAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(expectedWorkElements);
+
+            // Act
+            var objectResult = await _classUnderTest.GetWorkElements("12345678", 1, 25);
+            var statusCode = GetStatusCode(objectResult);
+            var result = GetResultData<List<WorkElementResponse>>(objectResult);
+
+            // Assert
+            statusCode.Should().Be((int) HttpStatusCode.OK);
+            result.Should().BeEquivalentTo(expectedWorkElements.Select(pe => pe.ToResponse()).ToList());
+        }
+
+        [Test]
+        public async Task GetWorkElementsReturnsBadRequestIfQueryIsMissing()
+        {
+            // Arrange
+
+            // Act
+            var objectResult = await _classUnderTest.GetWorkElements("", null, null);
+            var statusCode = GetStatusCode(objectResult);
+
+            // Assert
+            statusCode.Should().Be((int) HttpStatusCode.BadRequest);
+            _problemDetailsFactoryMock.VerifyStatusCode(HttpStatusCode.BadRequest);
+        }
+    }
+}

--- a/BonusCalcApi.Tests/V1/E2ETests/OperativeTests.cs
+++ b/BonusCalcApi.Tests/V1/E2ETests/OperativeTests.cs
@@ -26,6 +26,21 @@ namespace BonusCalcApi.Tests.V1.E2ETests
         }
 
         [Test]
+        public async Task CanGetOperatives()
+        {
+            // Arrange
+            var operatives = await SeedOperatives();
+            var operativeId = operatives.First().Id;
+
+            // Act
+            var (code, response) = await Get<List<OperativeResponse>>($"/api/v1/operatives?query={operativeId}");
+
+            // Assert
+            code.Should().Be(HttpStatusCode.OK);
+            response.Should().BeEquivalentTo(operatives.Select(o => o.ToResponse()).ToList());
+        }
+
+        [Test]
         public async Task CanGetOperative()
         {
             // Arrange
@@ -197,6 +212,13 @@ namespace BonusCalcApi.Tests.V1.E2ETests
             await Context.Operatives.AddAsync(operative);
             await Context.SaveChangesAsync();
             return operative;
+        }
+
+        private async Task<IEnumerable<Operative>> SeedOperatives()
+        {
+            return new List<Operative>(){
+                await SeedOperative()
+            };
         }
 
         private async Task<IEnumerable<PayElementType>> SeedPayElementTypes()

--- a/BonusCalcApi.Tests/V1/E2ETests/WorkElementTests.cs
+++ b/BonusCalcApi.Tests/V1/E2ETests/WorkElementTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using AutoFixture;
+using BonusCalcApi.Tests.V1.Helpers;
+using BonusCalcApi.V1.Boundary.Response;
+using BonusCalcApi.V1.Factories;
+using BonusCalcApi.V1.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace BonusCalcApi.Tests.V1.E2ETests
+{
+    public class WorkElementResponseComparer : IEqualityComparer<WorkElementResponse>
+    {
+        public bool Equals(WorkElementResponse we1, WorkElementResponse we2)
+        {
+            return we2.WorkOrder == we1.WorkOrder;
+        }
+
+        public int GetHashCode(WorkElementResponse we)
+        {
+            return we.WorkOrder.GetHashCode();
+        }
+    }
+
+    public class WorkElementTests : IntegrationTests<Startup>
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public async Task CanGetWorkElements()
+        {
+            // Arrange
+            await SeedPayElements();
+
+            var workElement = new WorkElementResponse()
+            {
+                WorkOrder = "12345678"
+            };
+
+            var otherWorkElement = new WorkElementResponse()
+            {
+                WorkOrder = "99999999"
+            };
+
+            var comparer = new WorkElementResponseComparer();
+
+            // Act
+            var (code, response) = await Get<List<WorkElementResponse>>($"/api/v1/work/elements?query=12345678");
+
+            // Assert
+            Assert.That(code, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response, Contains.Item(workElement).Using(comparer));
+            Assert.That(response, Does.Not.Contain(otherWorkElement).Using(comparer));
+        }
+
+        private async Task SeedPayElements()
+        {
+            var payElementType = new PayElementType
+            {
+                Id = 301,
+                Description = "Reactive Repairs",
+                PayAtBand = false,
+                Paid = true,
+                Adjustment = false,
+                Productive = true,
+                NonProductive = false,
+                OutOfHours = false,
+                Overtime = false,
+                Selectable = true,
+                SmvPerHour = null
+            };
+
+            var timesheet = new Timesheet
+            {
+                Id = "123456/2021-10-18",
+                Week = new Week
+                {
+                    Id = "2021-10-18",
+                    BonusPeriod = new BonusPeriod
+                    {
+                        Id = "2021-08-02",
+                        StartAt = new DateTime(2021, 8, 1, 23, 0, 0, DateTimeKind.Utc),
+                        Year = 2020,
+                        Number = 3,
+                        ClosedAt = null
+                    },
+                    StartAt = new DateTime(2021, 10, 17, 23, 0, 0, DateTimeKind.Utc),
+                    Number = 12,
+                    ClosedAt = null
+                },
+                Operative = new Operative
+                {
+                    Id = "123456",
+                    Name = "An Operative",
+                    EmailAddress = "an.operative@hackney.gov.uk",
+                    Trade = new Trade
+                    {
+                        Id = "CP",
+                        Description = "Carpenter"
+                    },
+                    Scheme = new Scheme
+                    {
+                        Id = 1,
+                        Type = "SMV",
+                        Description = "Reactive",
+                        ConversionFactor = 1.0M
+                    },
+                    Section = "H3007",
+                    SalaryBand = 5,
+                    Utilisation = 1.0M,
+                    FixedBand = false,
+                    IsArchived = false
+                }
+            };
+
+            var payElements = new List<PayElement>()
+            {
+                new PayElement()
+                {
+                    Timesheet = timesheet,
+                    PayElementType = payElementType,
+                    WorkOrder = "12345678",
+                    ClosedAt = new DateTime(2021, 10, 18, 11, 0, 0, DateTimeKind.Utc),
+                    Monday = 1.0M,
+                    Duration = 1.0M,
+                    Value = 60.0M,
+                    ReadOnly = true
+                },
+                new PayElement()
+                {
+                    Timesheet = timesheet,
+                    PayElementType = payElementType,
+                    WorkOrder = "99999999",
+                    ClosedAt = new DateTime(2021, 10, 19, 11, 0, 0, DateTimeKind.Utc),
+                    Tuesday = 1.0M,
+                    Duration = 1.0M,
+                    Value = 60.0M,
+                    ReadOnly = true
+                }
+            };
+
+            await Context.PayElementTypes.AddAsync(payElementType);
+            await Context.Timesheets.AddAsync(timesheet);
+            await Context.PayElements.AddRangeAsync(payElements);
+            await Context.SaveChangesAsync();
+        }
+    }
+}

--- a/BonusCalcApi.Tests/V1/Gateways/WorkElementGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/WorkElementGatewayTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Gateways;
+using BonusCalcApi.V1.Infrastructure;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BonusCalcApi.Tests.V1.Gateways
+{
+    public class WorkElementComparer : IEqualityComparer<WorkElement>
+    {
+        public bool Equals(WorkElement we1, WorkElement we2)
+        {
+            return we2.WorkOrder == we1.WorkOrder;
+        }
+
+        public int GetHashCode(WorkElement we)
+        {
+            return we.WorkOrder.GetHashCode();
+        }
+    }
+
+    [TestFixture]
+    public class WorkElementGatewayTests : DatabaseTests
+    {
+        private WorkElementGateway _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _classUnderTest = new WorkElementGateway(BonusCalcContext);
+        }
+
+        [Test]
+        public async Task RetrievesWorkElementsFromDB()
+        {
+            // Arrange
+            await AddPayElements();
+
+            var workElement = new WorkElement()
+            {
+                WorkOrder = "12345678"
+            };
+
+            var otherWorkElement = new WorkElement()
+            {
+                WorkOrder = "99999999"
+            };
+
+            var comparer = new WorkElementComparer();
+
+            // Act
+            var result = await _classUnderTest.GetWorkElementsAsync("12345678", 1, 25);
+
+            // Assert
+            Assert.That(result, Contains.Item(workElement).Using(comparer));
+            Assert.That(result, Does.Not.Contain(otherWorkElement).Using(comparer));
+        }
+
+        [Test]
+        public async Task RetrievesEmptyResultsFromDB()
+        {
+            // Act
+            var result = await _classUnderTest.GetWorkElementsAsync("00000000", 1, 25);
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        private async Task AddPayElements()
+        {
+            var payElementType = new PayElementType
+            {
+                Id = 301,
+                Description = "Reactive Repairs",
+                PayAtBand = false,
+                Paid = true,
+                Adjustment = false,
+                Productive = true,
+                NonProductive = false,
+                OutOfHours = false,
+                Overtime = false,
+                Selectable = true,
+                SmvPerHour = null
+            };
+
+            var timesheet = new Timesheet
+            {
+                Id = "123456/2021-10-18",
+                Week = new Week
+                {
+                    Id = "2021-10-18",
+                    BonusPeriod = new BonusPeriod
+                    {
+                        Id = "2021-08-02",
+                        StartAt = new DateTime(2021, 8, 1, 23, 0, 0, DateTimeKind.Utc),
+                        Year = 2020,
+                        Number = 3,
+                        ClosedAt = null
+                    },
+                    StartAt = new DateTime(2021, 10, 17, 23, 0, 0, DateTimeKind.Utc),
+                    Number = 12,
+                    ClosedAt = null
+                },
+                Operative = new Operative
+                {
+                    Id = "123456",
+                    Name = "An Operative",
+                    EmailAddress = "an.operative@hackney.gov.uk",
+                    Trade = new Trade
+                    {
+                        Id = "EL",
+                        Description = "Electrician"
+                    },
+                    Scheme = new Scheme
+                    {
+                        Id = 1,
+                        Type = "SMV",
+                        Description = "Reactive",
+                        ConversionFactor = 1.0M
+                    },
+                    Section = "H3007",
+                    SalaryBand = 5,
+                    Utilisation = 1.0M,
+                    FixedBand = false,
+                    IsArchived = false
+                }
+            };
+
+            var payElements = new List<PayElement>()
+            {
+                new PayElement()
+                {
+                    Timesheet = timesheet,
+                    PayElementType = payElementType,
+                    WorkOrder = "12345678",
+                    ClosedAt = new DateTime(2021, 10, 18, 11, 0, 0, DateTimeKind.Utc),
+                    Monday = 1.0M,
+                    Duration = 1.0M,
+                    Value = 60.0M,
+                    ReadOnly = true
+                },
+                new PayElement()
+                {
+                    Timesheet = timesheet,
+                    PayElementType = payElementType,
+                    WorkOrder = "99999999",
+                    ClosedAt = new DateTime(2021, 10, 19, 11, 0, 0, DateTimeKind.Utc),
+                    Tuesday = 1.0M,
+                    Duration = 1.0M,
+                    Value = 60.0M,
+                    ReadOnly = true
+                }
+            };
+
+            await BonusCalcContext.PayElementTypes.AddAsync(payElementType);
+            await BonusCalcContext.Timesheets.AddAsync(timesheet);
+            await BonusCalcContext.PayElements.AddRangeAsync(payElements);
+            await BonusCalcContext.SaveChangesAsync();
+        }
+    }
+}

--- a/BonusCalcApi.Tests/V1/UseCase/GetOperativesUseCaseTests.cs
+++ b/BonusCalcApi.Tests/V1/UseCase/GetOperativesUseCaseTests.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using AutoFixture;
+using BonusCalcApi.Tests.V1.Helpers;
+using BonusCalcApi.V1.Gateways;
+using BonusCalcApi.V1.Gateways.Interfaces;
+using BonusCalcApi.V1.Infrastructure;
+using BonusCalcApi.V1.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace BonusCalcApi.Tests.V1.UseCase
+{
+    public class GetOperativesUseCaseTests
+    {
+        private Mock<IOperativeGateway> _mockOperativeGateway;
+        private GetOperativesUseCase _classUnderTest;
+        private Fixture _fixture;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = FixtureHelpers.Fixture;
+            _mockOperativeGateway = new Mock<IOperativeGateway>();
+            _classUnderTest = new GetOperativesUseCase(_mockOperativeGateway.Object);
+        }
+        [Test]
+        public async Task GetOperatives()
+        {
+            // Arrange
+            var expectedOperatives = _fixture.CreateMany<Operative>();
+            _mockOperativeGateway
+                .Setup(x => x.GetOperativesAsync("123456", 1, 25))
+                .ReturnsAsync(expectedOperatives);
+
+            // Act
+            var result = await _classUnderTest.ExecuteAsync("123456", 1, 25);
+
+            // Assert
+            result.Should().BeEquivalentTo(expectedOperatives);
+        }
+    }
+}

--- a/BonusCalcApi.Tests/V1/UseCase/GetWorkElementsUseCaseTests.cs
+++ b/BonusCalcApi.Tests/V1/UseCase/GetWorkElementsUseCaseTests.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using AutoFixture;
+using BonusCalcApi.Tests.V1.Helpers;
+using BonusCalcApi.V1.Gateways;
+using BonusCalcApi.V1.Gateways.Interfaces;
+using BonusCalcApi.V1.Infrastructure;
+using BonusCalcApi.V1.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace BonusCalcApi.Tests.V1.UseCase
+{
+    public class GetWorkElementsUseCaseTests
+    {
+        private Mock<IWorkElementGateway> _mockWorkElementGateway;
+        private GetWorkElementsUseCase _classUnderTest;
+        private Fixture _fixture;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = FixtureHelpers.Fixture;
+            _mockWorkElementGateway = new Mock<IWorkElementGateway>();
+            _classUnderTest = new GetWorkElementsUseCase(_mockWorkElementGateway.Object);
+        }
+        [Test]
+        public async Task GetWorkElements()
+        {
+            // Arrange
+            var expectedWorkElements = _fixture.CreateMany<WorkElement>();
+            _mockWorkElementGateway
+                .Setup(x => x.GetWorkElementsAsync("12345678", 1, 25))
+                .ReturnsAsync(expectedWorkElements);
+
+            // Act
+            var result = await _classUnderTest.ExecuteAsync("12345678", 1, 25);
+
+            // Assert
+            result.Should().BeEquivalentTo(expectedWorkElements);
+        }
+    }
+}

--- a/BonusCalcApi.Tests/V1/UseCase/UpdateTimesheetUseCaseTests.cs
+++ b/BonusCalcApi.Tests/V1/UseCase/UpdateTimesheetUseCaseTests.cs
@@ -106,6 +106,7 @@ namespace BonusCalcApi.Tests.V1.UseCase
                 .Excluding(pe => pe.TimesheetId)
                 .Excluding(pe => pe.PayElementType)
                 .Excluding(pe => pe.ReadOnly)
+                .Excluding(pe => pe.SearchVector)
             );
             InMemoryDb.DbSaver.VerifySaveCalled();
         }

--- a/BonusCalcApi/BonusCalcApi.csproj
+++ b/BonusCalcApi/BonusCalcApi.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
+    <PackageReference Include="X.PagedList.Mvc.Core" Version="8.1.0" />
   </ItemGroup>
 
 </Project>

--- a/BonusCalcApi/Startup.cs
+++ b/BonusCalcApi/Startup.cs
@@ -199,6 +199,7 @@ namespace BonusCalcApi
         private static void RegisterUseCases(IServiceCollection services)
         {
             services.AddTransient<IGetOperativeUseCase, GetOperativeUseCase>();
+            services.AddTransient<IGetOperativesUseCase, GetOperativesUseCase>();
             services.AddTransient<IGetOperativeTimesheetUseCase, GetOperativeTimesheetUseCase>();
             services.AddTransient<IGetOperativeSummaryUseCase, GetOperativeSummaryUseCase>();
             services.AddTransient<IGetPayElementTypeUseCase, GetPayElementTypeUseCase>();

--- a/BonusCalcApi/Startup.cs
+++ b/BonusCalcApi/Startup.cs
@@ -193,6 +193,7 @@ namespace BonusCalcApi
             services.AddScoped<ITimesheetGateway, TimesheetGateway>();
             services.AddScoped<IPayElementTypeGateway, PayElementTypeGateway>();
             services.AddScoped<ISummaryGateway, SummaryGateway>();
+            services.AddScoped<IWorkElementGateway, WorkElementGateway>();
         }
 
         private static void RegisterUseCases(IServiceCollection services)
@@ -201,6 +202,7 @@ namespace BonusCalcApi
             services.AddTransient<IGetOperativeTimesheetUseCase, GetOperativeTimesheetUseCase>();
             services.AddTransient<IGetOperativeSummaryUseCase, GetOperativeSummaryUseCase>();
             services.AddTransient<IGetPayElementTypeUseCase, GetPayElementTypeUseCase>();
+            services.AddTransient<IGetWorkElementsUseCase, GetWorkElementsUseCase>();
             services.AddTransient<IUpdateTimesheetUseCase, UpdateTimesheetUseCase>();
         }
 

--- a/BonusCalcApi/V1/Boundary/Response/WorkElementResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/WorkElementResponse.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace BonusCalcApi.V1.Boundary.Response
+{
+    public class WorkElementResponse
+    {
+        public int Id { get; set; }
+
+        public string Type { get; set; }
+
+        public string WorkOrder { get; set; }
+
+        public string Address { get; set; }
+
+        public string Description { get; set; }
+
+        public string OperativeId { get; set; }
+
+        public string OperativeName { get; set; }
+
+        public string WeekId { get; set; }
+
+        public decimal Value { get; set; }
+
+        public DateTime? ClosedAt { get; set; }
+    }
+}

--- a/BonusCalcApi/V1/Controllers/WorkElementsController.cs
+++ b/BonusCalcApi/V1/Controllers/WorkElementsController.cs
@@ -1,0 +1,47 @@
+using BonusCalcApi.V1.Boundary.Response;
+using BonusCalcApi.V1.Controllers.Helpers;
+using BonusCalcApi.V1.Factories;
+using BonusCalcApi.V1.UseCase.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BonusCalcApi.V1.Controllers
+{
+    [ApiController]
+    [Route("api/v1/work")]
+    [Produces("application/json")]
+    [ApiVersion("1.0")]
+    public class WorkElementsController : BaseController
+    {
+        private readonly IGetWorkElementsUseCase _getWorkElementsUseCase;
+
+        public WorkElementsController(
+            IGetWorkElementsUseCase getWorkElementsUseCase
+        )
+        {
+            _getWorkElementsUseCase = getWorkElementsUseCase;
+        }
+
+        [HttpGet]
+        [ProducesResponseType(typeof(List<WorkElementResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        [Route("elements")]
+        public async Task<IActionResult> GetWorkElements([FromQuery][Required] string query, [FromQuery] int? page, [FromQuery] int? size)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+                return Problem(
+                    "The requested query is missing or invalid",
+                    $"/api/v1/work/elements?query={query}",
+                    StatusCodes.Status400BadRequest, "Bad Request"
+                );
+
+            var workElements = await _getWorkElementsUseCase.ExecuteAsync(query, page, size);
+            return Ok(workElements.Select(pe => pe.ToResponse()).ToList());
+        }
+    }
+}

--- a/BonusCalcApi/V1/Factories/ResponseFactory.cs
+++ b/BonusCalcApi/V1/Factories/ResponseFactory.cs
@@ -154,5 +154,22 @@ namespace BonusCalcApi.V1.Factories
                 AverageUtilisation = weeklySummary.AverageUtilisation
             };
         }
+
+        public static WorkElementResponse ToResponse(this WorkElement workElement)
+        {
+            return new WorkElementResponse
+            {
+                Id = workElement.Id,
+                Type = workElement.Type,
+                WorkOrder = workElement.WorkOrder,
+                Address = workElement.Address,
+                Description = workElement.Description,
+                OperativeId = workElement.OperativeId,
+                OperativeName = workElement.OperativeName,
+                WeekId = workElement.WeekId,
+                Value = workElement.Value,
+                ClosedAt = workElement.ClosedAt
+            };
+        }
     }
 }

--- a/BonusCalcApi/V1/Gateways/Interfaces/IOperativeGateway.cs
+++ b/BonusCalcApi/V1/Gateways/Interfaces/IOperativeGateway.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using BonusCalcApi.V1.Infrastructure;
 
@@ -6,5 +7,6 @@ namespace BonusCalcApi.V1.Gateways.Interfaces
     public interface IOperativeGateway
     {
         public Task<Operative> GetOperativeAsync(string operativeId);
+        public Task<IEnumerable<Operative>> GetOperativesAsync(string query, int? page, int? size);
     }
 }

--- a/BonusCalcApi/V1/Gateways/Interfaces/IWorkElementGateway.cs
+++ b/BonusCalcApi/V1/Gateways/Interfaces/IWorkElementGateway.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Infrastructure;
+
+namespace BonusCalcApi.V1.Gateways.Interfaces
+{
+    public interface IWorkElementGateway
+    {
+        public Task<IEnumerable<WorkElement>> GetWorkElementsAsync(string query, int? page, int? size);
+    }
+}

--- a/BonusCalcApi/V1/Gateways/OperativeGateway.cs
+++ b/BonusCalcApi/V1/Gateways/OperativeGateway.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using BonusCalcApi.V1.Gateways.Interfaces;
 using BonusCalcApi.V1.Infrastructure;
+using X.PagedList;
 
 namespace BonusCalcApi.V1.Gateways
 {
@@ -23,6 +25,20 @@ namespace BonusCalcApi.V1.Gateways
                 .Include(o => o.Scheme)
                 .ThenInclude(s => s.PayBands)
                 .SingleOrDefaultAsync(o => o.Id == operativeId);
+        }
+
+        public async Task<IEnumerable<Operative>> GetOperativesAsync(string query, int? page, int? size)
+        {
+            int pageNumber = Math.Clamp((page ?? 1), 1, 100);
+            int pageSize = Math.Clamp((size ?? 25), 1, 50);
+
+            return await _context.Operatives
+                .Include(o => o.Trade)
+                .Include(o => o.Scheme)
+                .ThenInclude(s => s.PayBands)
+                .Where(o => o.SearchVector.Matches(query))
+                .OrderBy(o => o.Name)
+                .ToPagedListAsync(pageNumber, pageSize);
         }
     }
 }

--- a/BonusCalcApi/V1/Gateways/WorkElementGateway.cs
+++ b/BonusCalcApi/V1/Gateways/WorkElementGateway.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using BonusCalcApi.V1.Gateways.Interfaces;
+using BonusCalcApi.V1.Infrastructure;
+using X.PagedList;
+
+namespace BonusCalcApi.V1.Gateways
+{
+    public class WorkElementGateway : IWorkElementGateway
+    {
+        private readonly BonusCalcContext _context;
+
+        public WorkElementGateway(BonusCalcContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<WorkElement>> GetWorkElementsAsync(string query, int? page, int? size)
+        {
+            int pageNumber = Math.Clamp((page ?? 1), 1, 1000);
+            int pageSize = Math.Clamp((size ?? 25), 1, 50);
+
+            return await _context.WorkElements
+                .Where(we => we.SearchVector.Matches(query))
+                .OrderBy(we => we.Id)
+                .ToPagedListAsync(pageNumber, pageSize);
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
+++ b/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
@@ -57,6 +57,13 @@ namespace BonusCalcApi.V1.Infrastructure
                 .HasPrecision(5, 4)
                 .HasDefaultValue(1.0);
 
+            modelBuilder.Entity<Operative>()
+                .HasGeneratedTsVectorColumn(
+                    o => o.SearchVector, "english",
+                    o => new { o.Id, o.Name, o.TradeId, o.Section })
+                .HasIndex(pe => pe.SearchVector)
+                .HasMethod("GIN");
+
             modelBuilder.Entity<PayBand>()
                 .Property(pb => pb.Id)
                 .ValueGeneratedNever();

--- a/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
+++ b/BonusCalcApi/V1/Infrastructure/BonusCalcContext.cs
@@ -20,6 +20,7 @@ namespace BonusCalcApi.V1.Infrastructure
         public DbSet<Week> Weeks { get; set; }
         public DbSet<Summary> Summaries { get; set; }
         public DbSet<WeeklySummary> WeeklySummaries { get; set; }
+        public DbSet<WorkElement> WorkElements { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -70,6 +71,9 @@ namespace BonusCalcApi.V1.Infrastructure
 
             modelBuilder.Entity<PayElement>()
                 .HasIndex(pe => pe.TimesheetId);
+
+            modelBuilder.Entity<PayElement>()
+                .HasIndex(pe => pe.WorkOrder);
 
             modelBuilder.Entity<PayElement>()
                 .HasOne(pe => pe.Timesheet)
@@ -126,6 +130,13 @@ namespace BonusCalcApi.V1.Infrastructure
                 .Property(pe => pe.Sunday)
                 .HasPrecision(10, 4)
                 .HasDefaultValue(0.0);
+
+            modelBuilder.Entity<PayElement>()
+                .HasGeneratedTsVectorColumn(
+                    pe => pe.SearchVector, "english",
+                    pe => new { pe.WorkOrder, pe.Address })
+                .HasIndex(pe => pe.SearchVector)
+                .HasMethod("GIN");
 
             modelBuilder.Entity<PayElementType>()
                 .Property(pet => pet.Id)
@@ -211,15 +222,22 @@ namespace BonusCalcApi.V1.Infrastructure
                 .WithMany(bp => bp.Weeks)
                 .HasForeignKey(w => w.BonusPeriodId);
 
-            modelBuilder
-                .Entity<Summary>()
+            modelBuilder.Entity<Summary>()
                 .ToView("summaries")
                 .HasKey(s => s.Id);
 
-            modelBuilder
-                .Entity<WeeklySummary>()
+            modelBuilder.Entity<WeeklySummary>()
                 .ToView("weekly_summaries")
                 .HasKey(ws => ws.Id);
+
+            modelBuilder
+                .Entity<WorkElement>()
+                .ToView("work_elements")
+                .HasKey(wo => wo.Id);
+
+            modelBuilder.Entity<WorkElement>()
+                .Property(we => we.Id)
+                .ValueGeneratedNever();
         }
     }
 }

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211202210048_AddSearchVectorToPayElements.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211202210048_AddSearchVectorToPayElements.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -10,9 +11,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211202210048_AddSearchVectorToPayElements")]
+    partial class AddSearchVectorToPayElements
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -211,7 +213,7 @@ namespace V1.Infrastructure.Migrations
                         .HasColumnType("tsvector")
                         .HasColumnName("search_vector")
                         .HasAnnotation("Npgsql:TsVectorConfig", "english")
-                        .HasAnnotation("Npgsql:TsVectorProperties", new[] { "WorkOrder", "Address" });
+                        .HasAnnotation("Npgsql:TsVectorProperties", new[] { "WorkOrder", "Address", "Comment" });
 
                     b.Property<decimal>("Sunday")
                         .ValueGeneratedOnAdd()
@@ -580,10 +582,6 @@ namespace V1.Infrastructure.Migrations
                     b.Property<string>("OperativeName")
                         .HasColumnType("text")
                         .HasColumnName("operative_name");
-
-                    b.Property<NpgsqlTsVector>("SearchVector")
-                        .HasColumnType("tsvector")
-                        .HasColumnName("search_vector");
 
                     b.Property<string>("Type")
                         .HasColumnType("text")

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211202210048_AddSearchVectorToPayElements.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211202210048_AddSearchVectorToPayElements.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NpgsqlTypes;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddSearchVectorToPayElements : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<NpgsqlTsVector>(
+                name: "search_vector",
+                table: "pay_elements",
+                type: "tsvector",
+                nullable: true)
+                .Annotation("Npgsql:TsVectorConfig", "english")
+                .Annotation("Npgsql:TsVectorProperties", new[] { "work_order", "address" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pay_elements_search_vector",
+                table: "pay_elements",
+                column: "search_vector")
+                .Annotation("Npgsql:IndexMethod", "GIN");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_pay_elements_search_vector",
+                table: "pay_elements");
+
+            migrationBuilder.DropColumn(
+                name: "search_vector",
+                table: "pay_elements");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211202210148_CreateWorkElementView.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211202210148_CreateWorkElementView.Designer.cs
@@ -3,16 +3,17 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using NpgsqlTypes;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211202210148_CreateWorkOrderView")]
+    partial class CreateWorkOrderView
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -206,13 +207,6 @@ namespace V1.Infrastructure.Migrations
                         .HasDefaultValue(0m)
                         .HasColumnName("saturday");
 
-                    b.Property<NpgsqlTsVector>("SearchVector")
-                        .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("tsvector")
-                        .HasColumnName("search_vector")
-                        .HasAnnotation("Npgsql:TsVectorConfig", "english")
-                        .HasAnnotation("Npgsql:TsVectorProperties", new[] { "WorkOrder", "Address" });
-
                     b.Property<decimal>("Sunday")
                         .ValueGeneratedOnAdd()
                         .HasPrecision(10, 4)
@@ -263,15 +257,8 @@ namespace V1.Infrastructure.Migrations
                     b.HasIndex("PayElementTypeId")
                         .HasDatabaseName("ix_pay_elements_pay_element_type_id");
 
-                    b.HasIndex("SearchVector")
-                        .HasDatabaseName("ix_pay_elements_search_vector")
-                        .HasMethod("GIN");
-
                     b.HasIndex("TimesheetId")
                         .HasDatabaseName("ix_pay_elements_timesheet_id");
-
-                    b.HasIndex("WorkOrder")
-                        .HasDatabaseName("ix_pay_elements_work_order");
 
                     b.ToTable("pay_elements");
                 });
@@ -553,58 +540,6 @@ namespace V1.Infrastructure.Migrations
                         .HasDatabaseName("ix_weekly_summaries_summary_id");
 
                     b.ToView("weekly_summaries");
-                });
-
-            modelBuilder.Entity("BonusCalcApi.V1.Infrastructure.WorkElement", b =>
-                {
-                    b.Property<int>("Id")
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    b.Property<string>("Address")
-                        .HasColumnType("text")
-                        .HasColumnName("address");
-
-                    b.Property<DateTime?>("ClosedAt")
-                        .HasColumnType("timestamp without time zone")
-                        .HasColumnName("closed_at");
-
-                    b.Property<string>("Description")
-                        .HasColumnType("text")
-                        .HasColumnName("description");
-
-                    b.Property<string>("OperativeId")
-                        .HasColumnType("text")
-                        .HasColumnName("operative_id");
-
-                    b.Property<string>("OperativeName")
-                        .HasColumnType("text")
-                        .HasColumnName("operative_name");
-
-                    b.Property<NpgsqlTsVector>("SearchVector")
-                        .HasColumnType("tsvector")
-                        .HasColumnName("search_vector");
-
-                    b.Property<string>("Type")
-                        .HasColumnType("text")
-                        .HasColumnName("type");
-
-                    b.Property<decimal>("Value")
-                        .HasColumnType("numeric")
-                        .HasColumnName("value");
-
-                    b.Property<string>("WeekId")
-                        .HasColumnType("text")
-                        .HasColumnName("week_id");
-
-                    b.Property<string>("WorkOrder")
-                        .HasColumnType("text")
-                        .HasColumnName("work_order");
-
-                    b.HasKey("Id")
-                        .HasName("pk_work_elements");
-
-                    b.ToView("work_elements");
                 });
 
             modelBuilder.Entity("BonusCalcApi.V1.Infrastructure.Operative", b =>

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211202210148_CreateWorkElementView.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211202210148_CreateWorkElementView.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class CreateWorkOrderView : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+CREATE VIEW work_elements AS
+SELECT
+    pe.id,
+    pet.description AS type,
+    pe.work_order,
+    pe.address,
+    pe.comment AS description,
+    t.operative_id,
+    o.name AS operative_name,
+    t.week_id,
+    pe.value,
+    pe.closed_at,
+    pe.search_vector
+FROM
+    pay_elements AS pe
+INNER JOIN
+    pay_element_types AS pet
+ON
+    pe.pay_element_type_id = pet.id
+INNER JOIN
+    timesheets AS t
+ON
+    pe.timesheet_id = t.id
+INNER JOIN
+    operatives AS o
+ON
+    t.operative_id = o.id;
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP VIEW work_elements");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211205132457_AddSearchVectorToOperatives.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211205132457_AddSearchVectorToOperatives.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -10,9 +11,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20211205132457_AddSearchVectorToOperatives")]
+    partial class AddSearchVectorToOperatives
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20211205132457_AddSearchVectorToOperatives.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20211205132457_AddSearchVectorToOperatives.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NpgsqlTypes;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddSearchVectorToOperatives : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<NpgsqlTsVector>(
+                name: "search_vector",
+                table: "operatives",
+                type: "tsvector",
+                nullable: true)
+                .Annotation("Npgsql:TsVectorConfig", "english")
+                .Annotation("Npgsql:TsVectorProperties", new[] { "id", "name", "trade_id", "section" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_operatives_search_vector",
+                table: "operatives",
+                column: "search_vector")
+                .Annotation("Npgsql:IndexMethod", "GIN");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_operatives_search_vector",
+                table: "operatives");
+
+            migrationBuilder.DropColumn(
+                name: "search_vector",
+                table: "operatives");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Operative.cs
+++ b/BonusCalcApi/V1/Infrastructure/Operative.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using NpgsqlTypes;
 
 namespace BonusCalcApi.V1.Infrastructure
 {
@@ -35,6 +36,8 @@ namespace BonusCalcApi.V1.Infrastructure
         public bool FixedBand { get; set; }
 
         public bool IsArchived { get; set; }
+
+        public NpgsqlTsVector SearchVector { get; set; }
 
         public List<Timesheet> Timesheets { get; set; }
     }

--- a/BonusCalcApi/V1/Infrastructure/PayElement.cs
+++ b/BonusCalcApi/V1/Infrastructure/PayElement.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using BonusCalcApi.V1.Boundary.Request;
+using NpgsqlTypes;
 
 namespace BonusCalcApi.V1.Infrastructure
 {
@@ -37,6 +38,8 @@ namespace BonusCalcApi.V1.Infrastructure
         public decimal Value { get; set; }
         public bool ReadOnly { get; set; }
         public DateTime? ClosedAt { get; set; }
+
+        public NpgsqlTsVector SearchVector { get; set; }
 
         public void UpdateFrom(PayElementUpdate payElement)
         {

--- a/BonusCalcApi/V1/Infrastructure/WorkElement.cs
+++ b/BonusCalcApi/V1/Infrastructure/WorkElement.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using NpgsqlTypes;
+
+namespace BonusCalcApi.V1.Infrastructure
+{
+    public class WorkElement
+    {
+        public int Id { get; set; }
+
+        public string Type { get; set; }
+
+        public string WorkOrder { get; set; }
+
+        public string Address { get; set; }
+
+        public string Description { get; set; }
+
+        public string OperativeId { get; set; }
+
+        public string OperativeName { get; set; }
+
+        public string WeekId { get; set; }
+
+        public decimal Value { get; set; }
+
+        public DateTime? ClosedAt { get; set; }
+
+        public NpgsqlTsVector SearchVector { get; set; }
+    }
+}

--- a/BonusCalcApi/V1/UseCase/GetOperativesUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/GetOperativesUseCase.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Gateways.Interfaces;
+using BonusCalcApi.V1.Infrastructure;
+using BonusCalcApi.V1.UseCase.Interfaces;
+
+namespace BonusCalcApi.V1.UseCase
+{
+    public class GetOperativesUseCase : IGetOperativesUseCase
+    {
+        private readonly IOperativeGateway _operativeGateway;
+
+        public GetOperativesUseCase(IOperativeGateway operativeGateway)
+        {
+            _operativeGateway = operativeGateway;
+        }
+
+        public async Task<IEnumerable<Operative>> ExecuteAsync(string query, int? page, int? size)
+        {
+            return await _operativeGateway.GetOperativesAsync(query, page, size);
+        }
+    }
+}

--- a/BonusCalcApi/V1/UseCase/GetWorkElementsUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/GetWorkElementsUseCase.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Gateways.Interfaces;
+using BonusCalcApi.V1.Infrastructure;
+using BonusCalcApi.V1.UseCase.Interfaces;
+
+namespace BonusCalcApi.V1.UseCase
+{
+    public class GetWorkElementsUseCase : IGetWorkElementsUseCase
+    {
+        private readonly IWorkElementGateway _workElementGateway;
+
+        public GetWorkElementsUseCase(IWorkElementGateway workElementGateway)
+        {
+            _workElementGateway = workElementGateway;
+        }
+
+        public async Task<IEnumerable<WorkElement>> ExecuteAsync(string query, int? page, int? size)
+        {
+            return await _workElementGateway.GetWorkElementsAsync(query, page, size);
+        }
+    }
+}

--- a/BonusCalcApi/V1/UseCase/Interfaces/IGetOperativesUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/Interfaces/IGetOperativesUseCase.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Infrastructure;
+
+namespace BonusCalcApi.V1.UseCase.Interfaces
+{
+    public interface IGetOperativesUseCase
+    {
+        public Task<IEnumerable<Operative>> ExecuteAsync(string query, int? page, int? size);
+    }
+}

--- a/BonusCalcApi/V1/UseCase/Interfaces/IGetWorkElementsUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/Interfaces/IGetWorkElementsUseCase.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Infrastructure;
+
+namespace BonusCalcApi.V1.UseCase.Interfaces
+{
+    public interface IGetWorkElementsUseCase
+    {
+        public Task<IEnumerable<WorkElement>> ExecuteAsync(string query, int? page, int? size);
+    }
+}


### PR DESCRIPTION
A new view-based entity `WorkElement` is used because we don't want to load all of the object hierarchy for the pay element.