### PR TITLE
Record when the report was sent for an operative

### DIFF
--- a/BonusCalcApi.Tests/V1/E2ETests/OperativeTests.cs
+++ b/BonusCalcApi.Tests/V1/E2ETests/OperativeTests.cs
@@ -125,6 +125,24 @@ namespace BonusCalcApi.Tests.V1.E2ETests
             }
         }
 
+        [Test]
+        public async Task CanUpdateReportSentAt()
+        {
+            // Arrange
+            var now = DateTime.UtcNow;
+            var operative = await SeedOperative();
+            var timesheet = await SeedTimesheet(operative);
+
+            // Act
+            var (postCode, _) = await Post<TimesheetResponse>($"/api/v1/operatives/{operative.Id}/timesheet/report/?week={timesheet.WeekId}", null);
+            var (getCode, response) = await Get<TimesheetResponse>($"/api/v1/operatives/{operative.Id}/timesheet?week={timesheet.WeekId}");
+
+            // Assert
+            postCode.Should().Be(HttpStatusCode.OK);
+            getCode.Should().Be(HttpStatusCode.OK);
+            response.ReportSentAt.Should().BeOnOrAfter(now);
+        }
+
         private static void ValidatePayElement(PayElementResponse payElement, PayElementUpdate expectedPayElement)
         {
             payElement.Address.Should().Be(expectedPayElement.Address);
@@ -196,6 +214,7 @@ namespace BonusCalcApi.Tests.V1.E2ETests
 
             var timesheet = _fixture.Build<Timesheet>()
                 .With(t => t.Utilisation, 1.0M)
+                .Without(t => t.ReportSentAt)
                 .With(t => t.OperativeId, operative.Id)
                 .Without(t => t.Operative)
                 .With(t => t.WeekId, week.Id)

--- a/BonusCalcApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/BonusCalcApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -28,6 +28,7 @@ namespace BonusCalcApi.Tests.V1.Factories
 
             // Assert
             result.Id.Should().Be(timesheet.Id);
+            result.ReportSentAt.Should().Be(timesheet.ReportSentAt);
             ValidateWeek(result.Week, timesheet.Week);
 
             foreach (var payElement in timesheet.PayElements)
@@ -118,6 +119,7 @@ namespace BonusCalcApi.Tests.V1.Factories
             weeklySummaryResponse.NonProductiveValue.Should().Be(weeklySummary.NonProductiveValue);
             weeklySummaryResponse.TotalValue.Should().Be(weeklySummary.TotalValue);
             weeklySummaryResponse.ProjectedValue.Should().Be(weeklySummary.ProjectedValue);
+            weeklySummaryResponse.ReportSentAt.Should().Be(weeklySummary.ReportSentAt);
         }
     }
 }

--- a/BonusCalcApi.Tests/V1/UseCase/UpdateReportSentAtUseCaseTests.cs
+++ b/BonusCalcApi.Tests/V1/UseCase/UpdateReportSentAtUseCaseTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading.Tasks;
+using AutoFixture;
+using BonusCalcApi.Tests.V1.Helpers;
+using BonusCalcApi.V1.Exceptions;
+using BonusCalcApi.V1.Factories;
+using BonusCalcApi.V1.Gateways.Interfaces;
+using BonusCalcApi.V1.Infrastructure;
+using BonusCalcApi.V1.UseCase;
+using FluentAssertions;
+using FluentAssertions.Common;
+using Moq;
+using NUnit.Framework;
+
+namespace BonusCalcApi.Tests.V1.UseCase
+{
+    public class UpdateReportSentAtUseCaseTests
+    {
+        private UpdateReportSentAtUseCase _classUnderTest;
+        private Fixture _fixture;
+        private Mock<ITimesheetGateway> _timesheetGatewayMock;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = FixtureHelpers.Fixture;
+
+            _timesheetGatewayMock = new Mock<ITimesheetGateway>();
+
+            _classUnderTest = new UpdateReportSentAtUseCase(_timesheetGatewayMock.Object, InMemoryDb.DbSaver);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            InMemoryDb.Teardown();
+        }
+
+        [Test]
+        public async Task ReportSentAtIsUpdateWhenNull()
+        {
+            // Arrange
+            var now = DateTime.UtcNow;
+            var timesheet = CreateExistingTimesheet(null);
+
+            // Act
+            await _classUnderTest.ExecuteAsync(timesheet.OperativeId, timesheet.WeekId);
+
+            // Assert
+            timesheet.ReportSentAt.Should().BeOnOrAfter(now);
+            InMemoryDb.DbSaver.VerifySaveCalled();
+        }
+
+        [Test]
+        public async Task ReportSentAtIsNotUpdatedWhenNotNull()
+        {
+            // Arrange
+            var reportSentAt = new DateTime(2021, 10, 22, 16, 0, 0, DateTimeKind.Utc);
+            var timesheet = CreateExistingTimesheet(reportSentAt);
+
+            // Act
+            await _classUnderTest.ExecuteAsync(timesheet.OperativeId, timesheet.WeekId);
+
+            // Assert
+            timesheet.ReportSentAt.Should().Be(reportSentAt);
+            InMemoryDb.DbSaver.VerifySaveNotCalled();
+        }
+
+        [Test]
+        public async Task ThrowsResourceNotFoundWhenTimesheetDoesntExist()
+        {
+            // Arrange
+            _timesheetGatewayMock.Setup(x => x.GetOperativeTimesheetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(null as Timesheet);
+
+            // Act
+            Func<Task> act = async () => await _classUnderTest.ExecuteAsync("1", "1");
+
+            // Assert
+            await act.Should().ThrowAsync<ResourceNotFoundException>();
+            InMemoryDb.DbSaver.VerifySaveNotCalled();
+        }
+
+        private Timesheet CreateExistingTimesheet(DateTime? reportSentAt)
+        {
+            var timesheet = _fixture.Build<Timesheet>()
+                .With(t => t.Utilisation, 1.0M)
+                .With(t => t.ReportSentAt, reportSentAt)
+                .Without(t => t.PayElements)
+                .Create();
+            _timesheetGatewayMock.Setup(x => x.GetOperativeTimesheetAsync(timesheet.OperativeId, timesheet.WeekId))
+                .ReturnsAsync(timesheet);
+            return timesheet;
+        }
+    }
+}

--- a/BonusCalcApi/Startup.cs
+++ b/BonusCalcApi/Startup.cs
@@ -211,6 +211,7 @@ namespace BonusCalcApi
             services.AddTransient<IGetSchemesUseCase, GetSchemesUseCase>();
             services.AddTransient<IGetWeekUseCase, GetWeekUseCase>();
             services.AddTransient<IGetWorkElementsUseCase, GetWorkElementsUseCase>();
+            services.AddTransient<IUpdateReportSentAtUseCase, UpdateReportSentAtUseCase>();
             services.AddTransient<IUpdateTimesheetUseCase, UpdateTimesheetUseCase>();
             services.AddTransient<IUpdateWeekUseCase, UpdateWeekUseCase>();
         }

--- a/BonusCalcApi/V1/Boundary/Response/OperativeSummaryResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/OperativeSummaryResponse.cs
@@ -25,5 +25,7 @@ namespace BonusCalcApi.V1.Boundary.Response
         public decimal ProjectedValue { get; set; }
 
         public decimal AverageUtilisation { get; set; }
+
+        public DateTime? ReportSentAt { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Boundary/Response/TimesheetResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/TimesheetResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace BonusCalcApi.V1.Boundary.Response
@@ -6,6 +7,7 @@ namespace BonusCalcApi.V1.Boundary.Response
     {
         public string Id { get; set; }
         public decimal Utilisation { get; set; }
+        public DateTime? ReportSentAt { get; set; }
         public WeekResponse Week { get; set; }
         public List<PayElementResponse> PayElements { get; set; }
     }

--- a/BonusCalcApi/V1/Boundary/Response/WeeklySummaryResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/WeeklySummaryResponse.cs
@@ -23,5 +23,7 @@ namespace BonusCalcApi.V1.Boundary.Response
         public decimal ProjectedValue { get; set; }
 
         public decimal AverageUtilisation { get; set; }
+
+        public DateTime? ReportSentAt { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Controllers/OperativesController.cs
+++ b/BonusCalcApi/V1/Controllers/OperativesController.cs
@@ -24,6 +24,7 @@ namespace BonusCalcApi.V1.Controllers
         private readonly IGetOperativesUseCase _getOperativesUseCase;
         private readonly IGetOperativeSummaryUseCase _getOperativeSummaryUseCase;
         private readonly IGetOperativeTimesheetUseCase _getOperativeTimesheetUseCase;
+        private readonly IUpdateReportSentAtUseCase _updateReportSentAtUseCase;
         private readonly IUpdateTimesheetUseCase _updateTimesheetUseCase;
 
         public OperativesController(
@@ -32,6 +33,7 @@ namespace BonusCalcApi.V1.Controllers
             IGetOperativesUseCase getOperativesUseCase,
             IGetOperativeSummaryUseCase getOperativeSummaryUseCase,
             IGetOperativeTimesheetUseCase getOperativeTimesheetUseCase,
+            IUpdateReportSentAtUseCase updateReportSentAtUseCase,
             IUpdateTimesheetUseCase updateTimesheetUseCase
         )
         {
@@ -40,6 +42,7 @@ namespace BonusCalcApi.V1.Controllers
             _getOperativesUseCase = getOperativesUseCase;
             _getOperativeSummaryUseCase = getOperativeSummaryUseCase;
             _getOperativeTimesheetUseCase = getOperativeTimesheetUseCase;
+            _updateReportSentAtUseCase = updateReportSentAtUseCase;
             _updateTimesheetUseCase = updateTimesheetUseCase;
         }
 
@@ -185,6 +188,29 @@ namespace BonusCalcApi.V1.Controllers
                 );
 
             await _updateTimesheetUseCase.ExecuteAsync(updateRequest, operativePayrollNumber, week);
+
+            return Ok();
+        }
+
+        [HttpPost]
+        [Route("{operativePayrollNumber}/timesheet/report")]
+        public async Task<IActionResult> UpdateReportSentAt([FromRoute][Required] string operativePayrollNumber, [FromQuery][Required] string week)
+        {
+            if (!IsValidPrn(operativePayrollNumber))
+                return Problem(
+                    "The requested payroll number is invalid",
+                    $"/api/v1/operatives/{operativePayrollNumber}/timesheet/report?week={week}",
+                    StatusCodes.Status400BadRequest, "Bad Request"
+                );
+
+            if (!IsValidDate(week))
+                return Problem(
+                    "The requested week is invalid",
+                    $"/api/v1/operatives/{operativePayrollNumber}/timesheet/report?week={week}",
+                    StatusCodes.Status400BadRequest, "Bad Request"
+                );
+
+            await _updateReportSentAtUseCase.ExecuteAsync(operativePayrollNumber, week);
 
             return Ok();
         }

--- a/BonusCalcApi/V1/Factories/ResponseFactory.cs
+++ b/BonusCalcApi/V1/Factories/ResponseFactory.cs
@@ -42,7 +42,8 @@ namespace BonusCalcApi.V1.Factories
                 TotalValue = operativeSummary.TotalValue,
                 Utilisation = operativeSummary.Utilisation,
                 ProjectedValue = operativeSummary.ProjectedValue,
-                AverageUtilisation = operativeSummary.AverageUtilisation
+                AverageUtilisation = operativeSummary.AverageUtilisation,
+                ReportSentAt = operativeSummary.ReportSentAt
             };
         }
 
@@ -52,6 +53,7 @@ namespace BonusCalcApi.V1.Factories
             {
                 Id = timesheet.Id,
                 Utilisation = timesheet.Utilisation,
+                ReportSentAt = timesheet.ReportSentAt,
                 Week = timesheet.Week.ToResponse(),
                 PayElements = timesheet.PayElements.Select(pe => pe.ToResponse()).ToList()
             };
@@ -184,7 +186,8 @@ namespace BonusCalcApi.V1.Factories
                 TotalValue = weeklySummary.TotalValue,
                 Utilisation = weeklySummary.Utilisation,
                 ProjectedValue = weeklySummary.ProjectedValue,
-                AverageUtilisation = weeklySummary.AverageUtilisation
+                AverageUtilisation = weeklySummary.AverageUtilisation,
+                ReportSentAt = weeklySummary.ReportSentAt
             };
         }
 

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20220103104934_AddReportSentAtToTimesheets.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20220103104934_AddReportSentAtToTimesheets.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -10,9 +11,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20220103104934_AddReportSentAtToTimesheets")]
+    partial class AddReportSentAtToTimesheets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -170,10 +172,6 @@ namespace V1.Infrastructure.Migrations
                     b.Property<decimal>("ProjectedValue")
                         .HasColumnType("numeric")
                         .HasColumnName("projected_value");
-
-                    b.Property<DateTime?>("ReportSentAt")
-                        .HasColumnType("timestamp without time zone")
-                        .HasColumnName("report_sent_at");
 
                     b.Property<int>("SchemeId")
                         .HasColumnType("integer")
@@ -626,10 +624,6 @@ namespace V1.Infrastructure.Migrations
                     b.Property<decimal>("ProjectedValue")
                         .HasColumnType("numeric")
                         .HasColumnName("projected_value");
-
-                    b.Property<DateTime?>("ReportSentAt")
-                        .HasColumnType("timestamp without time zone")
-                        .HasColumnName("report_sent_at");
 
                     b.Property<DateTime>("StartAt")
                         .HasColumnType("timestamp without time zone")

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20220103104934_AddReportSentAtToTimesheets.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20220103104934_AddReportSentAtToTimesheets.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddReportSentAtToTimesheets : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "report_sent_at",
+                table: "timesheets",
+                type: "timestamp without time zone",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "report_sent_at",
+                table: "timesheets");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20220103111915_AddReportSentAtToSummaryViews.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20220103111915_AddReportSentAtToSummaryViews.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -10,9 +11,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20220103111915_AddReportSentAtToSummaryViews")]
+    partial class AddReportSentAtToSummaryViews
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20220103111915_AddReportSentAtToSummaryViews.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20220103111915_AddReportSentAtToSummaryViews.cs
@@ -1,0 +1,165 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddReportSentAtToSummaryViews : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            DropViews(migrationBuilder);
+
+            migrationBuilder.Sql(@"
+CREATE VIEW weekly_summaries AS
+SELECT
+    CONCAT(t.operative_id, '/', w.bonus_period_id, '/', w.id) AS id,
+    CONCAT(t.operative_id, '/', w.bonus_period_id) AS summary_id,
+    w.id AS week_id,
+    t.operative_id,
+	w.number,
+	w.start_at,
+	w.closed_at,
+	COALESCE(p.value, 0)::numeric(10,4) AS productive_value,
+	COALESCE(np.duration, 0)::numeric(10,4) AS non_productive_duration,
+	COALESCE(np.value, 0)::numeric(10,4) AS non_productive_value,
+	(COALESCE(p.value, 0) + COALESCE(np.value, 0))::numeric(10,4) AS total_value,
+	t.utilisation,
+	ROUND(
+        AVG(COALESCE(p.value, 0) + COALESCE(np.value, 0))
+        OVER (
+            PARTITION BY w.bonus_period_id, t.operative_id
+            ORDER BY w.number ASC
+    ), 4)::numeric(10,4) AS projected_value,
+    ROUND(
+        AVG(t.utilisation)
+        OVER (
+            PARTITION BY w.bonus_period_id, t.operative_id
+            ORDER BY w.number ASC
+    ), 4)::numeric(5,4) AS average_utilisation,
+    t.report_sent_at
+FROM
+    weeks AS w
+INNER JOIN
+    timesheets AS t
+ON
+    w.id = t.week_id
+LEFT JOIN
+    productive_pay_elements AS p
+ON
+    t.id = p.timesheet_id
+LEFT JOIN
+    non_productive_pay_elements AS np
+ON t.id = np.timesheet_id
+            ");
+
+            migrationBuilder.Sql(@"
+CREATE VIEW operative_summaries AS
+SELECT
+    ws.operative_id AS id,
+    ws.week_id,
+    o.name,
+    o.trade_id,
+    t.description AS trade_description,
+    o.scheme_id,
+    ws.productive_value,
+    ws.non_productive_duration,
+    ws.non_productive_value,
+    ws.total_value,
+    ws.utilisation,
+    ws.projected_value,
+    ws.average_utilisation,
+    ws.report_sent_at
+FROM
+    weekly_summaries AS ws
+INNER JOIN
+    operatives AS o
+ON
+    ws.operative_id = o.id
+INNER JOIN
+    trades AS t
+ON
+    o.trade_id = t.id
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            DropViews(migrationBuilder);
+
+            migrationBuilder.Sql(@"
+CREATE VIEW weekly_summaries AS
+SELECT
+    CONCAT(t.operative_id, '/', w.bonus_period_id, '/', w.id) AS id,
+    CONCAT(t.operative_id, '/', w.bonus_period_id) AS summary_id,
+    w.id AS week_id,
+    t.operative_id,
+	w.number,
+	w.start_at,
+	w.closed_at,
+	COALESCE(p.value, 0)::numeric(10,4) AS productive_value,
+	COALESCE(np.duration, 0)::numeric(10,4) AS non_productive_duration,
+	COALESCE(np.value, 0)::numeric(10,4) AS non_productive_value,
+	(COALESCE(p.value, 0) + COALESCE(np.value, 0))::numeric(10,4) AS total_value,
+	t.utilisation,
+	ROUND(
+        AVG(COALESCE(p.value, 0) + COALESCE(np.value, 0))
+        OVER (
+            PARTITION BY w.bonus_period_id, t.operative_id
+            ORDER BY w.number ASC
+    ), 4)::numeric(10,4) AS projected_value,
+    ROUND(
+        AVG(t.utilisation)
+        OVER (
+            PARTITION BY w.bonus_period_id, t.operative_id
+            ORDER BY w.number ASC
+    ), 4)::numeric(5,4) AS average_utilisation
+FROM
+    weeks AS w
+INNER JOIN
+    timesheets AS t
+ON
+    w.id = t.week_id
+LEFT JOIN
+    productive_pay_elements AS p
+ON
+    t.id = p.timesheet_id
+LEFT JOIN
+    non_productive_pay_elements AS np
+ON t.id = np.timesheet_id
+            ");
+
+            migrationBuilder.Sql(@"
+CREATE VIEW operative_summaries AS
+SELECT
+    ws.operative_id AS id,
+    ws.week_id,
+    o.name,
+    o.trade_id,
+    t.description AS trade_description,
+    o.scheme_id,
+    ws.productive_value,
+    ws.non_productive_duration,
+    ws.non_productive_value,
+    ws.total_value,
+    ws.utilisation,
+    ws.projected_value,
+    ws.average_utilisation
+FROM
+    weekly_summaries AS ws
+INNER JOIN
+    operatives AS o
+ON
+    ws.operative_id = o.id
+INNER JOIN
+    trades AS t
+ON
+    o.trade_id = t.id
+            ");
+        }
+
+        protected static void DropViews(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP VIEW operative_summaries");
+            migrationBuilder.Sql("DROP VIEW weekly_summaries");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/OperativeSummary.cs
+++ b/BonusCalcApi/V1/Infrastructure/OperativeSummary.cs
@@ -31,5 +31,7 @@ namespace BonusCalcApi.V1.Infrastructure
         public decimal ProjectedValue { get; set; }
 
         public decimal AverageUtilisation { get; set; }
+
+        public DateTime? ReportSentAt { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Infrastructure/Timesheet.cs
+++ b/BonusCalcApi/V1/Infrastructure/Timesheet.cs
@@ -22,6 +22,8 @@ namespace BonusCalcApi.V1.Infrastructure
 
         public decimal Utilisation { get; set; }
 
+        public DateTime? ReportSentAt { get; set; }
+
         public List<PayElement> PayElements { get; set; }
     }
 }

--- a/BonusCalcApi/V1/Infrastructure/WeeklySummary.cs
+++ b/BonusCalcApi/V1/Infrastructure/WeeklySummary.cs
@@ -33,5 +33,7 @@ namespace BonusCalcApi.V1.Infrastructure
         public decimal ProjectedValue { get; set; }
 
         public decimal AverageUtilisation { get; set; }
+
+        public DateTime? ReportSentAt { get; set; }
     }
 }

--- a/BonusCalcApi/V1/UseCase/Interfaces/IUpdateReportSentAtUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/Interfaces/IUpdateReportSentAtUseCase.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Boundary.Request;
+
+namespace BonusCalcApi.V1.UseCase.Interfaces
+{
+    public interface IUpdateReportSentAtUseCase
+    {
+        public Task ExecuteAsync(string operativeId, string weekId);
+    }
+}

--- a/BonusCalcApi/V1/UseCase/UpdateReportSentAtUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/UpdateReportSentAtUseCase.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Gateways.Interfaces;
+using BonusCalcApi.V1.Infrastructure;
+using BonusCalcApi.V1.UseCase.Interfaces;
+
+namespace BonusCalcApi.V1.UseCase
+{
+    public class UpdateReportSentAtUseCase : IUpdateReportSentAtUseCase
+    {
+        private readonly ITimesheetGateway _timesheetGateway;
+        private readonly IDbSaver _dbSaver;
+        public UpdateReportSentAtUseCase(ITimesheetGateway timesheetGateway, IDbSaver dbSaver)
+        {
+            _timesheetGateway = timesheetGateway;
+            _dbSaver = dbSaver;
+        }
+        public async Task ExecuteAsync(string operativeId, string weekId)
+        {
+            var timesheet = await _timesheetGateway.GetOperativeTimesheetAsync(operativeId, weekId);
+
+            if (timesheet is null) ThrowHelper.ThrowNotFound($"Timesheet not found for operative: {operativeId} and week: {weekId}");
+
+            if (timesheet.ReportSentAt is null)
+            {
+                timesheet.ReportSentAt = DateTime.UtcNow;
+                await _dbSaver.SaveChangesAsync();
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
By recording when a report is sent and then updating the week closed_at once all operatives have a non-null report_sent_at then we can recover the week closing process in the middle should there be a failure like a browser being closed or crashing.

Similar to #56, this PR is based off an existing branch so it can be merged without needing to rebase when the previous PR is merged.