### PR TITLE
Add ReportsSentAt to Week entity

### DIFF
--- a/BonusCalcApi.Tests/V1/E2ETests/WeekTests.cs
+++ b/BonusCalcApi.Tests/V1/E2ETests/WeekTests.cs
@@ -94,6 +94,23 @@ namespace BonusCalcApi.Tests.V1.E2ETests
             Assert.That(response.ClosedBy, Is.EqualTo(update.ClosedBy));
         }
 
+        [Test]
+        public async Task CanUpdateReportsSentAt()
+        {
+            // Arrange
+            var now = DateTime.UtcNow;
+            var week = await SeedWeek();
+
+            // Act
+            var (postCode, _) = await Post<WeekResponse>($"/api/v1/weeks/2021-10-18/reports", null);
+            var (getCode, response) = await Get<WeekResponse>($"/api/v1/weeks/2021-10-18");
+
+            // Assert
+            postCode.Should().Be(HttpStatusCode.OK);
+            getCode.Should().Be(HttpStatusCode.OK);
+            response.ReportsSentAt.Should().BeOnOrAfter(now);
+        }
+
         private async Task<Week> SeedWeek()
         {
             var week = new Week
@@ -109,7 +126,8 @@ namespace BonusCalcApi.Tests.V1.E2ETests
                 },
                 StartAt = new DateTime(2021, 10, 17, 23, 0, 0, DateTimeKind.Utc),
                 Number = 12,
-                ClosedAt = null
+                ClosedAt = null,
+                ReportsSentAt = null
             };
 
             await Context.Weeks.AddAsync(week);

--- a/BonusCalcApi.Tests/V1/UseCase/UpdateReportsSentAtUseCaseTests.cs
+++ b/BonusCalcApi.Tests/V1/UseCase/UpdateReportsSentAtUseCaseTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading.Tasks;
+using AutoFixture;
+using BonusCalcApi.Tests.V1.Helpers;
+using BonusCalcApi.V1.Exceptions;
+using BonusCalcApi.V1.Factories;
+using BonusCalcApi.V1.Gateways.Interfaces;
+using BonusCalcApi.V1.Infrastructure;
+using BonusCalcApi.V1.UseCase;
+using FluentAssertions;
+using FluentAssertions.Common;
+using Moq;
+using NUnit.Framework;
+
+namespace BonusCalcApi.Tests.V1.UseCase
+{
+    public class UpdateReportsSentAtUseCaseTests
+    {
+        private UpdateReportsSentAtUseCase _classUnderTest;
+        private Fixture _fixture;
+        private Mock<IWeekGateway> _weekGatewayMock;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = FixtureHelpers.Fixture;
+
+            _weekGatewayMock = new Mock<IWeekGateway>();
+
+            _classUnderTest = new UpdateReportsSentAtUseCase(_weekGatewayMock.Object, InMemoryDb.DbSaver);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            InMemoryDb.Teardown();
+        }
+
+        [Test]
+        public async Task ReportsSentAtIsUpdateWhenNull()
+        {
+            // Arrange
+            var now = DateTime.UtcNow;
+            var week = CreateExistingWeek(null);
+
+            // Act
+            await _classUnderTest.ExecuteAsync(week.Id);
+
+            // Assert
+            week.ReportsSentAt.Should().BeOnOrAfter(now);
+            InMemoryDb.DbSaver.VerifySaveCalled();
+        }
+
+        [Test]
+        public async Task ReportsSentAtIsNotUpdatedWhenNotNull()
+        {
+            // Arrange
+            var reportsSentAt = new DateTime(2021, 10, 22, 16, 0, 0, DateTimeKind.Utc);
+            var week = CreateExistingWeek(reportsSentAt);
+
+            // Act
+            await _classUnderTest.ExecuteAsync(week.Id);
+
+            // Assert
+            week.ReportsSentAt.Should().Be(reportsSentAt);
+            InMemoryDb.DbSaver.VerifySaveNotCalled();
+        }
+
+        [Test]
+        public async Task ThrowsResourceNotFoundWhenWeekDoesntExist()
+        {
+            // Arrange
+            _weekGatewayMock.Setup(x => x.GetWeekAsync(It.IsAny<string>()))
+                .ReturnsAsync(null as Week);
+
+            // Act
+            Func<Task> act = async () => await _classUnderTest.ExecuteAsync("1");
+
+            // Assert
+            await act.Should().ThrowAsync<ResourceNotFoundException>();
+            InMemoryDb.DbSaver.VerifySaveNotCalled();
+        }
+
+        private Week CreateExistingWeek(DateTime? reportsSentAt)
+        {
+            var week = _fixture.Build<Week>()
+                .With(t => t.ReportsSentAt, reportsSentAt)
+                .Create();
+            _weekGatewayMock.Setup(x => x.GetWeekAsync(week.Id))
+                .ReturnsAsync(week);
+            return week;
+        }
+    }
+}

--- a/BonusCalcApi/Startup.cs
+++ b/BonusCalcApi/Startup.cs
@@ -212,6 +212,7 @@ namespace BonusCalcApi
             services.AddTransient<IGetWeekUseCase, GetWeekUseCase>();
             services.AddTransient<IGetWorkElementsUseCase, GetWorkElementsUseCase>();
             services.AddTransient<IUpdateReportSentAtUseCase, UpdateReportSentAtUseCase>();
+            services.AddTransient<IUpdateReportsSentAtUseCase, UpdateReportsSentAtUseCase>();
             services.AddTransient<IUpdateTimesheetUseCase, UpdateTimesheetUseCase>();
             services.AddTransient<IUpdateWeekUseCase, UpdateWeekUseCase>();
         }

--- a/BonusCalcApi/V1/Boundary/Response/WeekResponse.cs
+++ b/BonusCalcApi/V1/Boundary/Response/WeekResponse.cs
@@ -17,6 +17,8 @@ namespace BonusCalcApi.V1.Boundary.Response
 
         public string ClosedBy { get; set; }
 
+        public DateTime? ReportsSentAt { get; set; }
+
         public List<OperativeSummaryResponse> OperativeSummaries { get; set; }
 
         public bool ShouldSerializeBonusPeriod() => BonusPeriod != null;

--- a/BonusCalcApi/V1/Controllers/WeeksController.cs
+++ b/BonusCalcApi/V1/Controllers/WeeksController.cs
@@ -23,16 +23,19 @@ namespace BonusCalcApi.V1.Controllers
         private readonly IOperativeHelpers _operativeHelpers;
         private readonly IGetWeekUseCase _getWeekUseCase;
         private readonly IUpdateWeekUseCase _updateWeekUseCase;
+        private readonly IUpdateReportsSentAtUseCase _updateReportsSentAtUseCase;
 
         public WeeksController(
             IOperativeHelpers operativeHelpers,
             IGetWeekUseCase getWeekUseCase,
-            IUpdateWeekUseCase updateWeekUseCase
+            IUpdateWeekUseCase updateWeekUseCase,
+            IUpdateReportsSentAtUseCase updateReportsSentAtUseCase
         )
         {
             _operativeHelpers = operativeHelpers;
             _getWeekUseCase = getWeekUseCase;
             _updateWeekUseCase = updateWeekUseCase;
+            _updateReportsSentAtUseCase = updateReportsSentAtUseCase;
         }
 
         [HttpGet]
@@ -92,6 +95,23 @@ namespace BonusCalcApi.V1.Controllers
 
             return Ok(week.ToResponse());
         }
+
+        [HttpPost]
+        [Route("{weekId}/reports")]
+        public async Task<IActionResult> UpdateReportsSentAt([FromRoute][Required] string weekId)
+        {
+            if (!IsValidDate(weekId))
+                return Problem(
+                    "The requested week is invalid",
+                    $"/api/v1/weeks/{weekId}",
+                    StatusCodes.Status400BadRequest, "Bad Request"
+                );
+
+            await _updateReportsSentAtUseCase.ExecuteAsync(weekId);
+
+            return Ok();
+        }
+
         private bool IsValidDate(string date)
         {
             return _operativeHelpers.IsValidDate(date);

--- a/BonusCalcApi/V1/Factories/ResponseFactory.cs
+++ b/BonusCalcApi/V1/Factories/ResponseFactory.cs
@@ -75,6 +75,7 @@ namespace BonusCalcApi.V1.Factories
                 },
                 ClosedAt = week.ClosedAt,
                 ClosedBy = week.ClosedBy,
+                ReportsSentAt = week.ReportsSentAt,
                 StartAt = week.StartAt,
                 OperativeSummaries = week.OperativeSummaries?.Select(os => os.ToResponse()).ToList()
             };

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20220116175708_AddReportsSentAtToWeek.Designer.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20220116175708_AddReportsSentAtToWeek.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BonusCalcApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -10,9 +11,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BonusCalcContext))]
-    partial class BonusCalcContextModelSnapshot : ModelSnapshot
+    [Migration("20220116175708_AddReportsSentAtToWeek")]
+    partial class AddReportsSentAtToWeek
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BonusCalcApi/V1/Infrastructure/Migrations/20220116175708_AddReportsSentAtToWeek.cs
+++ b/BonusCalcApi/V1/Infrastructure/Migrations/20220116175708_AddReportsSentAtToWeek.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddReportsSentAtToWeek : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "reports_sent_at",
+                table: "weeks",
+                type: "timestamp without time zone",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "reports_sent_at",
+                table: "weeks");
+        }
+    }
+}

--- a/BonusCalcApi/V1/Infrastructure/Week.cs
+++ b/BonusCalcApi/V1/Infrastructure/Week.cs
@@ -25,6 +25,8 @@ namespace BonusCalcApi.V1.Infrastructure
         [StringLength(100)]
         public string ClosedBy { get; set; }
 
+        public DateTime? ReportsSentAt { get; set; }
+
         public List<Timesheet> Timesheets { get; set; }
 
         public List<OperativeSummary> OperativeSummaries { get; set; }

--- a/BonusCalcApi/V1/UseCase/Interfaces/IUpdateReportsSentAtUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/Interfaces/IUpdateReportsSentAtUseCase.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Boundary.Request;
+
+namespace BonusCalcApi.V1.UseCase.Interfaces
+{
+    public interface IUpdateReportsSentAtUseCase
+    {
+        public Task ExecuteAsync(string weekId);
+    }
+}

--- a/BonusCalcApi/V1/UseCase/UpdateReportSentAtUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/UpdateReportSentAtUseCase.cs
@@ -10,11 +10,13 @@ namespace BonusCalcApi.V1.UseCase
     {
         private readonly ITimesheetGateway _timesheetGateway;
         private readonly IDbSaver _dbSaver;
+
         public UpdateReportSentAtUseCase(ITimesheetGateway timesheetGateway, IDbSaver dbSaver)
         {
             _timesheetGateway = timesheetGateway;
             _dbSaver = dbSaver;
         }
+
         public async Task ExecuteAsync(string operativeId, string weekId)
         {
             var timesheet = await _timesheetGateway.GetOperativeTimesheetAsync(operativeId, weekId);
@@ -26,7 +28,6 @@ namespace BonusCalcApi.V1.UseCase
                 timesheet.ReportSentAt = DateTime.UtcNow;
                 await _dbSaver.SaveChangesAsync();
             }
-
         }
     }
 }

--- a/BonusCalcApi/V1/UseCase/UpdateReportsSentAtUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/UpdateReportsSentAtUseCase.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using BonusCalcApi.V1.Gateways.Interfaces;
+using BonusCalcApi.V1.Infrastructure;
+using BonusCalcApi.V1.UseCase.Interfaces;
+
+namespace BonusCalcApi.V1.UseCase
+{
+    public class UpdateReportsSentAtUseCase : IUpdateReportsSentAtUseCase
+    {
+        private readonly IWeekGateway _weekGateway;
+        private readonly IDbSaver _dbSaver;
+
+        public UpdateReportsSentAtUseCase(IWeekGateway weekGateway, IDbSaver dbSaver)
+        {
+            _weekGateway = weekGateway;
+            _dbSaver = dbSaver;
+        }
+
+        public async Task ExecuteAsync(string weekId)
+        {
+            var week = await _weekGateway.GetWeekAsync(weekId);
+
+            if (week is null) ThrowHelper.ThrowNotFound($"Week not found for: {weekId}");
+
+            if (week.ReportsSentAt is null)
+            {
+                week.ReportsSentAt = DateTime.UtcNow;
+                await _dbSaver.SaveChangesAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
The sending of reports may be interrupted so we need to know when all reports have been sent. To facilitate this add a ReportsSentAt attribute to the Week entity which is updated once all reports have been sent via Notify by the frontend application.
