### PR TITLE
Rename use cases to prevent future confusion

### DIFF
--- a/BonusCalcApi.Tests/V1/Controllers/OperativesControllerTests.cs
+++ b/BonusCalcApi.Tests/V1/Controllers/OperativesControllerTests.cs
@@ -32,7 +32,7 @@ namespace BonusCalcApi.Tests.V1.Controllers
         private MockOperativeHelpers _operativeHelpers;
         private Mock<IGetOperativeSummaryUseCase> _getOperativeSummaryUseCaseMock;
         private Mock<IGetOperativeTimesheetUseCase> _getOperativeTimesheetUseCaseMock;
-        private Mock<IUpdateReportSentAtUseCase> _updateReportSentAtUseCaseMock;
+        private Mock<IUpdateOperativeReportSentAtUseCase> _updateOperativeReportSentAtUseCaseMock;
         private Mock<IUpdateTimesheetUseCase> _updateTimesheetUseCaseMock;
 
         [SetUp]
@@ -45,7 +45,7 @@ namespace BonusCalcApi.Tests.V1.Controllers
             _getOperativeSummaryUseCaseMock = new Mock<IGetOperativeSummaryUseCase>();
             _getOperativeTimesheetUseCaseMock = new Mock<IGetOperativeTimesheetUseCase>();
             _updateTimesheetUseCaseMock = new Mock<IUpdateTimesheetUseCase>();
-            _updateReportSentAtUseCaseMock = new Mock<IUpdateReportSentAtUseCase>();
+            _updateOperativeReportSentAtUseCaseMock = new Mock<IUpdateOperativeReportSentAtUseCase>();
             _operativeHelpers = new MockOperativeHelpers();
             _problemDetailsFactoryMock = new MockProblemDetailsFactory();
 
@@ -55,7 +55,7 @@ namespace BonusCalcApi.Tests.V1.Controllers
                 _getOperativesUseCaseMock.Object,
                 _getOperativeSummaryUseCaseMock.Object,
                 _getOperativeTimesheetUseCaseMock.Object,
-                _updateReportSentAtUseCaseMock.Object,
+                _updateOperativeReportSentAtUseCaseMock.Object,
                 _updateTimesheetUseCaseMock.Object
             );
 
@@ -354,7 +354,7 @@ namespace BonusCalcApi.Tests.V1.Controllers
 
             // Assert
             statusCode.Should().Be((int) HttpStatusCode.OK);
-            _updateReportSentAtUseCaseMock.Verify(x => x.ExecuteAsync(expectedOperativeId, expectedWeekId));
+            _updateOperativeReportSentAtUseCaseMock.Verify(x => x.ExecuteAsync(expectedOperativeId, expectedWeekId));
         }
 
         [Test]

--- a/BonusCalcApi.Tests/V1/Controllers/WeeksControllerTests.cs
+++ b/BonusCalcApi.Tests/V1/Controllers/WeeksControllerTests.cs
@@ -25,7 +25,7 @@ namespace BonusCalcApi.Tests.V1.Controllers
         private Fixture _fixture;
         private Mock<IGetWeekUseCase> _getWeekUseCaseMock;
         private Mock<IUpdateWeekUseCase> _updateWeekUseCaseMock;
-        private Mock<IUpdateReportsSentAtUseCase> _updateReportsSentAtUseCaseMock;
+        private Mock<IUpdateWeekReportsSentAtUseCase> _updateWeekReportsSentAtUseCaseMock;
         private MockOperativeHelpers _operativeHelpers;
         private MockProblemDetailsFactory _problemDetailsFactoryMock;
 
@@ -38,14 +38,14 @@ namespace BonusCalcApi.Tests.V1.Controllers
             _operativeHelpers = new MockOperativeHelpers();
             _getWeekUseCaseMock = new Mock<IGetWeekUseCase>();
             _updateWeekUseCaseMock = new Mock<IUpdateWeekUseCase>();
-            _updateReportsSentAtUseCaseMock = new Mock<IUpdateReportsSentAtUseCase>();
+            _updateWeekReportsSentAtUseCaseMock = new Mock<IUpdateWeekReportsSentAtUseCase>();
             _problemDetailsFactoryMock = new MockProblemDetailsFactory();
 
             _classUnderTest = new WeeksController(
                 _operativeHelpers.Object,
                 _getWeekUseCaseMock.Object,
                 _updateWeekUseCaseMock.Object,
-                _updateReportsSentAtUseCaseMock.Object
+                _updateWeekReportsSentAtUseCaseMock.Object
             );
 
             // .NET 3.1 doesn't set ProblemDetailsFactory so we need to mock it
@@ -177,11 +177,11 @@ namespace BonusCalcApi.Tests.V1.Controllers
 
             // Assert
             statusCode.Should().Be((int) HttpStatusCode.OK);
-            _updateReportsSentAtUseCaseMock.Verify(x => x.ExecuteAsync(expectedWeekId));
+            _updateWeekReportsSentAtUseCaseMock.Verify(x => x.ExecuteAsync(expectedWeekId));
         }
 
         [Test]
-        public async Task UpdateReportsSentAtReturnsBadRequestIfWeekIsInvalid()
+        public async Task UpdateWeekReportsSentAtReturnsBadRequestIfWeekIsInvalid()
         {
             // Arrange
             _operativeHelpers.ValidDate(false);

--- a/BonusCalcApi.Tests/V1/UseCase/UpdateOperativeReportSentAtUseCaseTests.cs
+++ b/BonusCalcApi.Tests/V1/UseCase/UpdateOperativeReportSentAtUseCaseTests.cs
@@ -14,9 +14,9 @@ using NUnit.Framework;
 
 namespace BonusCalcApi.Tests.V1.UseCase
 {
-    public class UpdateReportSentAtUseCaseTests
+    public class UpdateOperativeReportSentAtUseCaseTests
     {
-        private UpdateReportSentAtUseCase _classUnderTest;
+        private UpdateOperativeReportSentAtUseCase _classUnderTest;
         private Fixture _fixture;
         private Mock<ITimesheetGateway> _timesheetGatewayMock;
 
@@ -27,7 +27,7 @@ namespace BonusCalcApi.Tests.V1.UseCase
 
             _timesheetGatewayMock = new Mock<ITimesheetGateway>();
 
-            _classUnderTest = new UpdateReportSentAtUseCase(_timesheetGatewayMock.Object, InMemoryDb.DbSaver);
+            _classUnderTest = new UpdateOperativeReportSentAtUseCase(_timesheetGatewayMock.Object, InMemoryDb.DbSaver);
         }
 
         [TearDown]

--- a/BonusCalcApi.Tests/V1/UseCase/UpdateWeekReportsSentAtUseCaseTests.cs
+++ b/BonusCalcApi.Tests/V1/UseCase/UpdateWeekReportsSentAtUseCaseTests.cs
@@ -14,9 +14,9 @@ using NUnit.Framework;
 
 namespace BonusCalcApi.Tests.V1.UseCase
 {
-    public class UpdateReportsSentAtUseCaseTests
+    public class UpdateWeekReportsSentAtUseCaseTests
     {
-        private UpdateReportsSentAtUseCase _classUnderTest;
+        private UpdateWeekReportsSentAtUseCase _classUnderTest;
         private Fixture _fixture;
         private Mock<IWeekGateway> _weekGatewayMock;
 
@@ -27,7 +27,7 @@ namespace BonusCalcApi.Tests.V1.UseCase
 
             _weekGatewayMock = new Mock<IWeekGateway>();
 
-            _classUnderTest = new UpdateReportsSentAtUseCase(_weekGatewayMock.Object, InMemoryDb.DbSaver);
+            _classUnderTest = new UpdateWeekReportsSentAtUseCase(_weekGatewayMock.Object, InMemoryDb.DbSaver);
         }
 
         [TearDown]

--- a/BonusCalcApi/Startup.cs
+++ b/BonusCalcApi/Startup.cs
@@ -211,8 +211,8 @@ namespace BonusCalcApi
             services.AddTransient<IGetSchemesUseCase, GetSchemesUseCase>();
             services.AddTransient<IGetWeekUseCase, GetWeekUseCase>();
             services.AddTransient<IGetWorkElementsUseCase, GetWorkElementsUseCase>();
-            services.AddTransient<IUpdateReportSentAtUseCase, UpdateReportSentAtUseCase>();
-            services.AddTransient<IUpdateReportsSentAtUseCase, UpdateReportsSentAtUseCase>();
+            services.AddTransient<IUpdateOperativeReportSentAtUseCase, UpdateOperativeReportSentAtUseCase>();
+            services.AddTransient<IUpdateWeekReportsSentAtUseCase, UpdateWeekReportsSentAtUseCase>();
             services.AddTransient<IUpdateTimesheetUseCase, UpdateTimesheetUseCase>();
             services.AddTransient<IUpdateWeekUseCase, UpdateWeekUseCase>();
         }

--- a/BonusCalcApi/V1/Controllers/OperativesController.cs
+++ b/BonusCalcApi/V1/Controllers/OperativesController.cs
@@ -24,7 +24,7 @@ namespace BonusCalcApi.V1.Controllers
         private readonly IGetOperativesUseCase _getOperativesUseCase;
         private readonly IGetOperativeSummaryUseCase _getOperativeSummaryUseCase;
         private readonly IGetOperativeTimesheetUseCase _getOperativeTimesheetUseCase;
-        private readonly IUpdateReportSentAtUseCase _updateReportSentAtUseCase;
+        private readonly IUpdateOperativeReportSentAtUseCase _updateOperativeReportSentAtUseCase;
         private readonly IUpdateTimesheetUseCase _updateTimesheetUseCase;
 
         public OperativesController(
@@ -33,7 +33,7 @@ namespace BonusCalcApi.V1.Controllers
             IGetOperativesUseCase getOperativesUseCase,
             IGetOperativeSummaryUseCase getOperativeSummaryUseCase,
             IGetOperativeTimesheetUseCase getOperativeTimesheetUseCase,
-            IUpdateReportSentAtUseCase updateReportSentAtUseCase,
+            IUpdateOperativeReportSentAtUseCase updateOperativeReportSentAtUseCase,
             IUpdateTimesheetUseCase updateTimesheetUseCase
         )
         {
@@ -42,7 +42,7 @@ namespace BonusCalcApi.V1.Controllers
             _getOperativesUseCase = getOperativesUseCase;
             _getOperativeSummaryUseCase = getOperativeSummaryUseCase;
             _getOperativeTimesheetUseCase = getOperativeTimesheetUseCase;
-            _updateReportSentAtUseCase = updateReportSentAtUseCase;
+            _updateOperativeReportSentAtUseCase = updateOperativeReportSentAtUseCase;
             _updateTimesheetUseCase = updateTimesheetUseCase;
         }
 
@@ -210,7 +210,7 @@ namespace BonusCalcApi.V1.Controllers
                     StatusCodes.Status400BadRequest, "Bad Request"
                 );
 
-            await _updateReportSentAtUseCase.ExecuteAsync(operativePayrollNumber, week);
+            await _updateOperativeReportSentAtUseCase.ExecuteAsync(operativePayrollNumber, week);
 
             return Ok();
         }

--- a/BonusCalcApi/V1/Controllers/WeeksController.cs
+++ b/BonusCalcApi/V1/Controllers/WeeksController.cs
@@ -23,19 +23,19 @@ namespace BonusCalcApi.V1.Controllers
         private readonly IOperativeHelpers _operativeHelpers;
         private readonly IGetWeekUseCase _getWeekUseCase;
         private readonly IUpdateWeekUseCase _updateWeekUseCase;
-        private readonly IUpdateReportsSentAtUseCase _updateReportsSentAtUseCase;
+        private readonly IUpdateWeekReportsSentAtUseCase _updateWeekReportsSentAtUseCase;
 
         public WeeksController(
             IOperativeHelpers operativeHelpers,
             IGetWeekUseCase getWeekUseCase,
             IUpdateWeekUseCase updateWeekUseCase,
-            IUpdateReportsSentAtUseCase updateReportsSentAtUseCase
+            IUpdateWeekReportsSentAtUseCase updateWeekReportsSentAtUseCase
         )
         {
             _operativeHelpers = operativeHelpers;
             _getWeekUseCase = getWeekUseCase;
             _updateWeekUseCase = updateWeekUseCase;
-            _updateReportsSentAtUseCase = updateReportsSentAtUseCase;
+            _updateWeekReportsSentAtUseCase = updateWeekReportsSentAtUseCase;
         }
 
         [HttpGet]
@@ -107,7 +107,7 @@ namespace BonusCalcApi.V1.Controllers
                     StatusCodes.Status400BadRequest, "Bad Request"
                 );
 
-            await _updateReportsSentAtUseCase.ExecuteAsync(weekId);
+            await _updateWeekReportsSentAtUseCase.ExecuteAsync(weekId);
 
             return Ok();
         }

--- a/BonusCalcApi/V1/UseCase/Interfaces/IUpdateOperativeReportSentAtUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/Interfaces/IUpdateOperativeReportSentAtUseCase.cs
@@ -3,7 +3,7 @@ using BonusCalcApi.V1.Boundary.Request;
 
 namespace BonusCalcApi.V1.UseCase.Interfaces
 {
-    public interface IUpdateReportSentAtUseCase
+    public interface IUpdateOperativeReportSentAtUseCase
     {
         public Task ExecuteAsync(string operativeId, string weekId);
     }

--- a/BonusCalcApi/V1/UseCase/Interfaces/IUpdateWeekReportsSentAtUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/Interfaces/IUpdateWeekReportsSentAtUseCase.cs
@@ -3,7 +3,7 @@ using BonusCalcApi.V1.Boundary.Request;
 
 namespace BonusCalcApi.V1.UseCase.Interfaces
 {
-    public interface IUpdateReportsSentAtUseCase
+    public interface IUpdateWeekReportsSentAtUseCase
     {
         public Task ExecuteAsync(string weekId);
     }

--- a/BonusCalcApi/V1/UseCase/UpdateOperativeReportSentAtUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/UpdateOperativeReportSentAtUseCase.cs
@@ -6,12 +6,12 @@ using BonusCalcApi.V1.UseCase.Interfaces;
 
 namespace BonusCalcApi.V1.UseCase
 {
-    public class UpdateReportSentAtUseCase : IUpdateReportSentAtUseCase
+    public class UpdateOperativeReportSentAtUseCase : IUpdateOperativeReportSentAtUseCase
     {
         private readonly ITimesheetGateway _timesheetGateway;
         private readonly IDbSaver _dbSaver;
 
-        public UpdateReportSentAtUseCase(ITimesheetGateway timesheetGateway, IDbSaver dbSaver)
+        public UpdateOperativeReportSentAtUseCase(ITimesheetGateway timesheetGateway, IDbSaver dbSaver)
         {
             _timesheetGateway = timesheetGateway;
             _dbSaver = dbSaver;

--- a/BonusCalcApi/V1/UseCase/UpdateWeekReportsSentAtUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/UpdateWeekReportsSentAtUseCase.cs
@@ -6,12 +6,12 @@ using BonusCalcApi.V1.UseCase.Interfaces;
 
 namespace BonusCalcApi.V1.UseCase
 {
-    public class UpdateReportsSentAtUseCase : IUpdateReportsSentAtUseCase
+    public class UpdateWeekReportsSentAtUseCase : IUpdateWeekReportsSentAtUseCase
     {
         private readonly IWeekGateway _weekGateway;
         private readonly IDbSaver _dbSaver;
 
-        public UpdateReportsSentAtUseCase(IWeekGateway weekGateway, IDbSaver dbSaver)
+        public UpdateWeekReportsSentAtUseCase(IWeekGateway weekGateway, IDbSaver dbSaver)
         {
             _weekGateway = weekGateway;
             _dbSaver = dbSaver;


### PR DESCRIPTION
The `UpdateReportSentAt` and `UpdateReportsSentAt` use cases differ by just the one character so prefix with the entity name to prevent confusion in the future.
