### PR TITLE
Remove invalid --account option for sls command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@"<3.0.0"
       - run:
           name: Build lambda
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./BonusCalcApi/
-            sls deploy --stage <<parameters.stage>> --account <<parameters.aws-account>> --conceal
+            sls deploy --stage <<parameters.stage>> --conceal
   migrate-database:
     description: "Migrate database"
     parameters:

--- a/BonusCalcApi/serverless.yml
+++ b/BonusCalcApi/serverless.yml
@@ -1,5 +1,7 @@
 service: bonuscalc-api
 
+frameworkVersion: '2'
+
 provider:
   name: aws
   runtime: dotnetcore3.1


### PR DESCRIPTION
The latest release of the Serverless cli now raise an error for unrecognised options.
