### PR TITLE
Add out-of-hours overtime fix to migration scripts

### DIFF
--- a/data/migrations/20220124-190000-correct-overtime-pay-elements/README.md
+++ b/data/migrations/20220124-190000-correct-overtime-pay-elements/README.md
@@ -2,7 +2,9 @@
 
 ## Description
 
-Between 18:25 on 13th January, 2022 and 18:06 on 18th January, 2022 all work orders closed in Repairs Hub were flagged as being paid as overtime. This migration corrects the errors for work orders closed by operatives on their mobile devices during normal hours. This can be done automatically since they wouldn't have been presented with the overtime option when closing. There will need to be a follow on migration that corrects it for work orders outside of normal hours since there is no way to identify whether the overtime option was selected deliberately.
+Between 18:25 on 13th January, 2022 and 18:06 on 18th January, 2022 all work orders closed in Repairs Hub were flagged as being paid as overtime. There are 371 in-hours work orders flagged as overtime which should be paid as SMVs into the bonus calculation scheme. There are 111 out-of-hours work orders which could either be paid as SMVs or a monetary amount. A survey of affected operatives was made to determine which of those 111 work orders should be paid as SMVs.
+
+This script compiles a list of work orders that should be paid as SMVs and then deletes the relevant overtime pay elements from Bonus Calculation database. It then inserts new productive pay element records to correct the operative bonus calculations.
 
 ## Operations
 
@@ -12,11 +14,14 @@ Between 18:25 on 13th January, 2022 and 18:06 on 18th January, 2022 all work ord
     $ psql <repairs-hub-db-url> -f export-work-order-corrections.sql
     ```
 
-    This will generate a `work_order_corrections.csv` file in this directory. The output from the command should be as follows:
+    This will generate `in_hours_work_order_corrections.csv` and `out_of_hours_work_order_corrections.csv` files in this directory. The output from the command should be as follows:
 
     ```
     CREATE VIEW
+    CREATE VIEW
     COPY 404
+    COPY 69
+    DROP VIEW
     DROP VIEW
     ```
 
@@ -33,9 +38,10 @@ Between 18:25 on 13th January, 2022 and 18:06 on 18th January, 2022 all work ord
     ```
     CREATE TABLE
     COPY 404
+    COPY 69
     BEGIN
-    DELETE 402
-    INSERT 0 404
+    DELETE 471
+    INSERT 0 473
     COMMIT
     DROP TABLE
     ```
@@ -45,7 +51,7 @@ Between 18:25 on 13th January, 2022 and 18:06 on 18th January, 2022 all work ord
 3.  Remove the file exported in the first step, e.g:
 
     ``` sh
-    $ rm work_order_corrections.csv
+    $ rm in_hours_work_order_corrections.csv out_of_hours_work_order_corrections.csv
     ```
 
 4.  Check the [Bonus Calculation][1] application to ensure corrections have been successfully applied.

--- a/data/migrations/20220124-190000-correct-overtime-pay-elements/apply-work-order-corrections.sql
+++ b/data/migrations/20220124-190000-correct-overtime-pay-elements/apply-work-order-corrections.sql
@@ -11,7 +11,8 @@ CREATE TEMPORARY TABLE work_order_corrections (
 );
 
 -- Import work order corrections
-\COPY work_order_corrections(work_order, status_code, address_line, description_of_work, closed_date, payroll_number, job_percentage, total_smv) FROM 'work_order_corrections.csv' CSV HEADER;
+\COPY work_order_corrections(work_order, status_code, address_line, description_of_work, closed_date, payroll_number, job_percentage, total_smv) FROM 'in_hours_work_order_corrections.csv' CSV HEADER;
+\COPY work_order_corrections(work_order, status_code, address_line, description_of_work, closed_date, payroll_number, job_percentage, total_smv) FROM 'out_of_hours_work_order_corrections.csv' CSV HEADER;
 
 -- Wrap the changes in a transaction to ensure they're applied as a whole
 BEGIN;

--- a/data/migrations/20220124-190000-correct-overtime-pay-elements/export-work-order-corrections.sql
+++ b/data/migrations/20220124-190000-correct-overtime-pay-elements/export-work-order-corrections.sql
@@ -1,9 +1,9 @@
 -- The \COPY command needs to be on one line so we create
--- a temporary view as our query is complex
-CREATE TEMPORARY VIEW work_order_corrections AS
+-- a temporary views as our queries are complex
+CREATE TEMPORARY VIEW in_hours_work_order_corrections AS
 
--- Dump operative SMVs based on query in:
--- https://github.com/LBHackney-IT/repairs-api-dotnet/pull/566
+-- Dump in-hours operative SMVs based on query in:
+-- https://github.com/LBHackney-IT/repairs-api-dotnet/pull/566/files#diff-68d1d2a4a5b3f28f7c80054a2b59fe0030811f60730d4f7d23662f655afc31a5
 --
 -- Additionally filters out 'No Access' work orders as they were not
 -- affected in the Bonus Calculation database
@@ -29,11 +29,11 @@ WHERE wo.id IN (
   FROM job_status_updates as jsu
   INNER JOIN work_orders as wo
   ON jsu.related_work_order_id = wo.id
-  WHERE wo.status_code = 50
+  WHERE wo.status_code = 50 AND wo.is_overtime
   AND jsu.event_time >= '2022-01-13 18:25:47'
   AND jsu.event_time <= '2022-01-18 18:06:01'
   AND jsu.other_type = 'complete'
-  AND jsu.author_email IN (SELECT DISTINCT(email) FROM operatives WHERE email IS NOT NULL)
+  AND jsu.author_email IN (SELECT DISTINCT(email) FROM operatives WHERE email IS NOT NULL AND name NOT LIKE '%(SVY)%')
   AND (
     (jsu.event_time >= '2022-01-14 08:00:00' AND jsu.event_time < '2022-01-14 16:00:00') OR
     (jsu.event_time >= '2022-01-17 08:00:00' AND jsu.event_time < '2022-01-17 16:00:00') OR
@@ -43,9 +43,61 @@ WHERE wo.id IN (
 GROUP BY wo.id, wo.status_code, pa.address_line, wo.description_of_work, wo.closed_date, o.payroll_number, woo.job_percentage
 ORDER BY wo.id;
 
--- Export query results to a CSV file
-\COPY (SELECT * FROM work_order_corrections) TO 'work_order_corrections.csv' CSV HEADER;
+-- Dump out-of-hours operative SMVs based on query in:
+-- https://github.com/LBHackney-IT/repairs-api-dotnet/pull/566/files#diff-fdfd01aeb18d203fd4cf7dbf47ebeb64645ecc672095095858472a47715738d9
+--
+-- Additionally filters out 'No Access' work orders as they were not
+-- affected in the Bonus Calculation database
+CREATE TEMPORARY VIEW out_of_hours_work_order_corrections AS
+SELECT
+  wo.id AS work_order,
+  wo.status_code,
+  pa.address_line,
+  wo.description_of_work,
+  wo.closed_date,
+  o.payroll_number,
+  woo.job_percentage,
+  SUM(rsi.quantity_amount * sc.standard_minute_value) AS total_smv
+FROM work_orders AS wo
+INNER JOIN work_order_operatives AS woo ON wo.id = woo.work_order_id
+INNER JOIN property_class AS pc ON wo.site_id = pc.site_id
+INNER JOIN property_address AS pa ON pc.address_id = pa.id
+INNER JOIN work_elements AS we ON wo.id = we.work_order_id
+INNER JOIN rate_schedule_item AS rsi ON we.id = rsi.work_element_id
+INNER JOIN sor_codes AS sc ON rsi.custom_code = sc.code
+INNER JOIN operatives AS o ON woo.operative_id = o.id
+WHERE wo.id IN (
+  SELECT DISTINCT(wo.id)
+  FROM temp_overtime_operative_payment_types_13_jan_18_jan AS tmp
+  INNER JOIN work_order_operatives AS woo ON woo.operative_id = tmp.operative_id
+  INNER JOIN work_orders AS wo ON wo.id = woo.work_order_id
+  INNER JOIN job_status_updates AS jsu ON jsu.related_work_order_id = wo.id
+  WHERE wo.status_code = 50 AND wo.is_overtime
+  AND jsu.author_email IN (SELECT DISTINCT(email) FROM operatives WHERE email IS NOT NULL AND name NOT LIKE '%(SVY)%')
+  AND jsu.other_type = 'complete'
+  AND (
+    (tmp.thursday_13_jan_pm_payment_type = 'bonus' AND wo.closed_date BETWEEN '2022-01-13 18:25:47' AND '2022-01-13 23:59:59') OR
+    (tmp.friday_14_jan_am_payment_type = 'bonus' AND wo.closed_date BETWEEN '2022-01-14 00:00:00' AND '2022-01-14 08:00:00') OR
+    (tmp.friday_14_jan_pm_payment_type = 'bonus' AND wo.closed_date BETWEEN '2022-01-14 16:00:00' AND '2022-01-14 23:59:59') OR
+    (tmp.weekend_15_16_jan_payment_type = 'bonus' AND wo.closed_date BETWEEN '2022-01-15 00:00:00' AND '2022-01-16 23:59:59') OR
+    (tmp.monday_17_jan_am_payment_type = 'bonus' AND wo.closed_date BETWEEN '2022-01-17 00:00:00' AND '2022-01-17 08:00:00') OR
+    (tmp.monday_17_jan_pm_payment_type = 'bonus' AND wo.closed_date BETWEEN '2022-01-17 16:00:00' AND '2022-01-17 23:59:59') OR
+    (tmp.tuesday_18_jan_am_payment_type = 'bonus' AND wo.closed_date BETWEEN '2022-01-18 00:00:00' AND '2022-01-18 08:00:00') OR
+    (tmp.tuesday_18_jan_pm_payment_type = 'bonus' AND wo.closed_date BETWEEN '2022-01-18 16:00:00' AND '2022-01-18 19:06:01')
+  )
+  AND wo.id NOT IN (
+    10051370, 10051518, 10052203, 10056280, 10056478,
+    10056289, 10056327, 10055031, 10055064, 10055069
+  )
+)
+GROUP BY wo.id, wo.status_code, pa.address_line, wo.description_of_work, wo.closed_date, o.payroll_number, woo.job_percentage
+ORDER BY wo.id;
 
--- We created the view as temporary so PostgreSQL will clean
--- it up anyway but we'll drop it here for the sake of completeness
-DROP VIEW work_order_corrections;
+-- Export query results to a CSV file
+\COPY (SELECT * FROM in_hours_work_order_corrections) TO 'in_hours_work_order_corrections.csv' CSV HEADER;
+\COPY (SELECT * FROM out_of_hours_work_order_corrections) TO 'out_of_hours_work_order_corrections.csv' CSV HEADER;
+
+-- We created the views as temporary so PostgreSQL will clean
+-- it up anyway but we'll drop them here for the sake of completeness
+DROP VIEW in_hours_work_order_corrections;
+DROP VIEW out_of_hours_work_order_corrections;


### PR DESCRIPTION
This is a follow up to #60 and adds the out-of-hours work orders that need to be fixed based on a survey of affected operatives.