### PR TITLE
Increase the overtime rate from £21.60 to £21.98

### DIFF
--- a/BonusCalcApi.Tests/V1/E2ETests/WeekTests.cs
+++ b/BonusCalcApi.Tests/V1/E2ETests/WeekTests.cs
@@ -506,7 +506,7 @@ namespace BonusCalcApi.Tests.V1.E2ETests
                         new PayElement
                         {
                             PayElementType = payElementType,
-                            Value = 21.6M,
+                            Value = 21.98M,
                             ReadOnly = true
                         }
                     }
@@ -537,7 +537,7 @@ namespace BonusCalcApi.Tests.V1.E2ETests
                         new PayElement
                         {
                             PayElementType = payElementType,
-                            Value = 21.6M,
+                            Value = 21.98M,
                             ReadOnly = true
                         }
                     }
@@ -575,7 +575,7 @@ namespace BonusCalcApi.Tests.V1.E2ETests
                         new PayElement
                         {
                             PayElementType = payElementType,
-                            Value = 21.6M,
+                            Value = 21.98M,
                             ReadOnly = true
                         }
                     }

--- a/BonusCalcApi.Tests/V1/Gateways/OutOfHoursSummaryGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/OutOfHoursSummaryGatewayTests.cs
@@ -141,7 +141,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                         new PayElement()
                         {
                             PayElementType = payElementType,
-                            Value = 21.6M,
+                            Value = 21.98M,
                             ReadOnly = true
                         }
                     }
@@ -163,7 +163,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                         new PayElement()
                         {
                             PayElementType = payElementType,
-                            Value = 21.6M,
+                            Value = 21.98M,
                             ReadOnly = true
                         }
                     }

--- a/BonusCalcApi.Tests/V1/Gateways/OvertimeSummaryGatewayTests.cs
+++ b/BonusCalcApi.Tests/V1/Gateways/OvertimeSummaryGatewayTests.cs
@@ -141,7 +141,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                         new PayElement()
                         {
                             PayElementType = payElementType,
-                            Value = 21.6M,
+                            Value = 21.98M,
                             ReadOnly = true
                         }
                     }
@@ -163,7 +163,7 @@ namespace BonusCalcApi.Tests.V1.Gateways
                         new PayElement()
                         {
                             PayElementType = payElementType,
-                            Value = 21.6M,
+                            Value = 21.98M,
                             ReadOnly = true
                         }
                     }


### PR DESCRIPTION
This is purely a cosmetic change in the API - the actual figures are set by the listener and the frontend.
