### PR TITLE
Terraform - Minor version bump (DB)

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -65,7 +65,7 @@ module "database" {
   db_port = local.db_port
   subnet_ids = data.aws_subnet_ids.private_subnets.ids
   db_engine = "postgres"
-  db_engine_version = "12.7"
+  db_engine_version = "12.8"
   db_instance_class = "db.t3.small"
   db_allocated_storage = 20
   maintenance_window = "sun:04:00-sun:04:30"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -65,7 +65,7 @@ module "database" {
   db_port = local.db_port
   subnet_ids = data.aws_subnet_ids.private_subnets.ids
   db_engine = "postgres"
-  db_engine_version = "12.7"
+  db_engine_version = "12.8"
   db_instance_class = "db.t3.micro"
   db_allocated_storage = 20
   maintenance_window = "sun:04:00-sun:04:30"


### PR DESCRIPTION
CircleCI failure ([here](https://app.circleci.com/pipelines/github/LBHackney-IT/bonuscalc-api/226/workflows/622334bb-a296-41ea-b344-e09c85a07694/jobs/821)) because postgres has been bumped outside the TF definition - bring back in to line.

No changes for us to be concerned about in this minor version change ([release notes](https://www.postgresql.org/docs/12/release-12-8.html))