### PR TITLE
Add data migration to fix errors in split work orders

### DIFF
--- a/data/migrations/20220422-190000-correct-split-work-orders/README.md
+++ b/data/migrations/20220422-190000-correct-split-work-orders/README.md
@@ -1,0 +1,61 @@
+# Correct Split Work Orders
+
+## Description
+
+Up until 13th April, 2022 there existed a race condition in the DRS sync operation that would convert a split work order back to a single operative work order where a sync operation occurred during the interval between the split occurring and the work order being closed.
+
+This script compiles a list of affected work orders and then deletes the relevant pay elements from Bonus Calculation database. It then inserts new pay element records to correct the operative bonus calculations as well as overtime and out-of-hours pay elements.
+
+## Operations
+
+1.  Export the operative work order data by running the `export-work-order-corrections.sql` script, e.g:
+
+    ``` sh
+    $ psql <repairs-hub-db-url> -f export-work-order-corrections.sql
+    ```
+
+    This will generate a `work_order_corrections.csv` file in this directory. The output from the command should be as follows:
+
+    ```
+    CREATE VIEW
+    COPY 1761
+    DROP VIEW
+    ```
+
+    Anything else suggests an error and it should be raised in the development Slack channel.
+
+2.  Run the corrections script against the Bonus Calculation database, e.g:
+
+    ``` sh
+    $ psql <bonus-calculation-db-url> -f apply-work-order-corrections.sql
+    ```
+
+    The output from the command should be as follows:
+
+    ```
+    CREATE TABLE
+    COPY 1761
+    BEGIN
+    DELETE 1657
+    INSERT 0 1677
+    INSERT 0 80
+    INSERT 0 2
+    INSERT 0 0
+    INSERT 0 2
+    INSERT 0 0
+    UPDATE 0
+    COMMIT
+    DROP TABLE
+    ```
+
+    Anything else suggests an error and it should be raised in the development Slack channel.
+
+3.  Remove the file exported in the first step, e.g:
+
+    ``` sh
+    $ rm work_order_corrections.csv
+    ```
+
+4.  Check the [Bonus Calculation][1] application to ensure corrections have been successfully applied.
+
+[1]: https://dlo-bonus-scheme.hackney.gov.uk/manage/weeks

--- a/data/migrations/20220422-190000-correct-split-work-orders/apply-work-order-corrections.sql
+++ b/data/migrations/20220422-190000-correct-split-work-orders/apply-work-order-corrections.sql
@@ -1,0 +1,295 @@
+-- Create temporary table to hold records dumped from Repairs Hub database
+CREATE TEMPORARY TABLE work_order_corrections (
+  work_order varchar(10) NOT NULL,
+  status_code integer NOT NULL,
+  contractor_reference varchar(3),
+  address_line text,
+  description_of_work text,
+  closed_date timestamp without time zone NOT NULL,
+  payroll_number varchar(6) NOT NULL,
+  job_percentage numeric NOT NULL,
+  total_smv numeric NOT NULL,
+  operative_cost numeric NOT NULL,
+  is_overtime boolean NOT NULL,
+  is_outofhours boolean NOT NULL
+);
+
+-- Import work order corrections
+\COPY work_order_corrections(work_order, status_code, contractor_reference, address_line, description_of_work, closed_date, payroll_number, job_percentage, total_smv, operative_cost, is_overtime, is_outofhours) FROM 'work_order_corrections.csv' CSV HEADER;
+
+-- Wrap the changes in a transaction to ensure they're applied as a whole
+BEGIN;
+
+-- Remove the existing overtime pay elements as not all were created
+DELETE FROM pay_elements
+WHERE work_order IN (
+  SELECT DISTINCT(work_order) FROM work_order_corrections
+);
+
+-- Insert new productive pay elements that were completed
+INSERT INTO pay_elements (
+  timesheet_id, pay_element_type_id, work_order, cost_code, address,
+  comment, closed_at, value, duration, monday, tuesday, wednesday,
+  thursday, friday, saturday, sunday, read_only
+)
+SELECT
+  CONCAT(payroll_number, '/', TO_CHAR(DATE_TRUNC('week', closed_date), 'YYYY-MM-DD')) AS timesheet_id,
+  301 AS pay_element_type_id,
+  work_order,
+  CASE
+  WHEN contractor_reference = 'H01' THEN 'H3009'
+  WHEN contractor_reference = 'H02' THEN 'H3007'
+  WHEN contractor_reference = 'H03' THEN 'H3015'
+  WHEN contractor_reference = 'H04' THEN 'H3002'
+  WHEN contractor_reference = 'H05' THEN 'H3002'
+  WHEN contractor_reference = 'H06' THEN 'H3003'
+  WHEN contractor_reference = 'H07' THEN 'H3010'
+  WHEN contractor_reference = 'H08' THEN 'H3002'
+  WHEN contractor_reference = 'H09' THEN 'H3005'
+  WHEN contractor_reference = 'H10' THEN 'H3010'
+  WHEN contractor_reference = 'H11' THEN 'H3016'
+  WHEN contractor_reference = 'H12' THEN 'H3004'
+  WHEN contractor_reference = 'H13' THEN 'H3008'
+  WHEN contractor_reference = 'H14' THEN 'H1040'
+  WHEN contractor_reference = 'H15' THEN 'H1039'
+  END AS cost_code,
+  address_line AS address,
+  description_of_work AS comment,
+  closed_date AS closed_at,
+  ROUND(total_smv * job_percentage / 100, 4) AS value,
+  ROUND((total_smv * job_percentage / 100) / 60, 4) AS duration,
+  CASE EXTRACT(isodow FROM closed_date) WHEN 1 THEN ROUND((total_smv * job_percentage / 100) / 60, 4) ELSE 0 END AS monday,
+  CASE EXTRACT(isodow FROM closed_date) WHEN 2 THEN ROUND((total_smv * job_percentage / 100) / 60, 4) ELSE 0 END AS tuesday,
+  CASE EXTRACT(isodow FROM closed_date) WHEN 3 THEN ROUND((total_smv * job_percentage / 100) / 60, 4) ELSE 0 END AS wednesday,
+  CASE EXTRACT(isodow FROM closed_date) WHEN 4 THEN ROUND((total_smv * job_percentage / 100) / 60, 4) ELSE 0 END AS thursday,
+  CASE EXTRACT(isodow FROM closed_date) WHEN 5 THEN ROUND((total_smv * job_percentage / 100) / 60, 4) ELSE 0 END AS friday,
+  CASE EXTRACT(isodow FROM closed_date) WHEN 6 THEN ROUND((total_smv * job_percentage / 100) / 60, 4) ELSE 0 END AS saturday,
+  CASE EXTRACT(isodow FROM closed_date) WHEN 7 THEN ROUND((total_smv * job_percentage / 100) / 60, 4) ELSE 0 END AS sunday,
+  true AS read_only
+FROM work_order_corrections
+WHERE status_code = 50 AND is_outofhours = false AND is_overtime = false;
+
+-- Insert new productive pay elements that were closed as 'No Access'
+INSERT INTO pay_elements (
+  timesheet_id, pay_element_type_id, work_order, cost_code, address,
+  comment, closed_at, value, duration, monday, tuesday, wednesday,
+  thursday, friday, saturday, sunday, read_only
+)
+SELECT
+  CONCAT(payroll_number, '/', TO_CHAR(DATE_TRUNC('week', closed_date), 'YYYY-MM-DD')) AS timesheet_id,
+  301 AS pay_element_type_id,
+  work_order,
+  CASE
+  WHEN contractor_reference = 'H01' THEN 'H3009'
+  WHEN contractor_reference = 'H02' THEN 'H3007'
+  WHEN contractor_reference = 'H03' THEN 'H3015'
+  WHEN contractor_reference = 'H04' THEN 'H3002'
+  WHEN contractor_reference = 'H05' THEN 'H3002'
+  WHEN contractor_reference = 'H06' THEN 'H3003'
+  WHEN contractor_reference = 'H07' THEN 'H3010'
+  WHEN contractor_reference = 'H08' THEN 'H3002'
+  WHEN contractor_reference = 'H09' THEN 'H3005'
+  WHEN contractor_reference = 'H10' THEN 'H3010'
+  WHEN contractor_reference = 'H11' THEN 'H3016'
+  WHEN contractor_reference = 'H12' THEN 'H3004'
+  WHEN contractor_reference = 'H13' THEN 'H3008'
+  WHEN contractor_reference = 'H14' THEN 'H1040'
+  WHEN contractor_reference = 'H15' THEN 'H1039'
+  END AS cost_code,
+  address_line AS address,
+  description_of_work AS comment,
+  closed_date AS closed_at,
+  0 AS value,
+  0 AS duration,
+  0 AS monday,
+  0 AS tuesday,
+  0 AS wednesday,
+  0 AS thursday,
+  0 AS friday,
+  0 AS saturday,
+  0 AS sunday,
+  true AS read_only
+FROM work_order_corrections
+WHERE status_code = 1000 AND is_outofhours = false AND is_overtime = false;
+
+-- Insert new overtime pay elements that were completed
+INSERT INTO pay_elements (
+  timesheet_id, pay_element_type_id, work_order, cost_code, address,
+  comment, closed_at, value, duration, monday, tuesday, wednesday,
+  thursday, friday, saturday, sunday, read_only
+)
+SELECT
+  CONCAT(payroll_number, '/', TO_CHAR(DATE_TRUNC('week', closed_date), 'YYYY-MM-DD')) AS timesheet_id,
+  401 AS pay_element_type_id,
+  work_order,
+  CASE
+  WHEN contractor_reference = 'H01' THEN 'H3009'
+  WHEN contractor_reference = 'H02' THEN 'H3007'
+  WHEN contractor_reference = 'H03' THEN 'H3015'
+  WHEN contractor_reference = 'H04' THEN 'H3002'
+  WHEN contractor_reference = 'H05' THEN 'H3002'
+  WHEN contractor_reference = 'H06' THEN 'H3003'
+  WHEN contractor_reference = 'H07' THEN 'H3010'
+  WHEN contractor_reference = 'H08' THEN 'H3002'
+  WHEN contractor_reference = 'H09' THEN 'H3005'
+  WHEN contractor_reference = 'H10' THEN 'H3010'
+  WHEN contractor_reference = 'H11' THEN 'H3016'
+  WHEN contractor_reference = 'H12' THEN 'H3004'
+  WHEN contractor_reference = 'H13' THEN 'H3008'
+  WHEN contractor_reference = 'H14' THEN 'H1040'
+  WHEN contractor_reference = 'H15' THEN 'H1039'
+  END AS cost_code,
+  address_line AS address,
+  description_of_work AS comment,
+  closed_date AS closed_at,
+  21.6 AS value,
+  0 AS duration,
+  0 AS monday,
+  0 AS tuesday,
+  0 AS wednesday,
+  0 AS thursday,
+  0 AS friday,
+  0 AS saturday,
+  0 AS sunday,
+  true AS read_only
+FROM work_order_corrections
+WHERE status_code = 50 AND is_overtime = true;
+
+-- Insert new overtime pay elements that were closed as 'No Access'
+INSERT INTO pay_elements (
+  timesheet_id, pay_element_type_id, work_order, cost_code, address,
+  comment, closed_at, value, duration, monday, tuesday, wednesday,
+  thursday, friday, saturday, sunday, read_only
+)
+SELECT
+  CONCAT(payroll_number, '/', TO_CHAR(DATE_TRUNC('week', closed_date), 'YYYY-MM-DD')) AS timesheet_id,
+  401 AS pay_element_type_id,
+  work_order,
+  CASE
+  WHEN contractor_reference = 'H01' THEN 'H3009'
+  WHEN contractor_reference = 'H02' THEN 'H3007'
+  WHEN contractor_reference = 'H03' THEN 'H3015'
+  WHEN contractor_reference = 'H04' THEN 'H3002'
+  WHEN contractor_reference = 'H05' THEN 'H3002'
+  WHEN contractor_reference = 'H06' THEN 'H3003'
+  WHEN contractor_reference = 'H07' THEN 'H3010'
+  WHEN contractor_reference = 'H08' THEN 'H3002'
+  WHEN contractor_reference = 'H09' THEN 'H3005'
+  WHEN contractor_reference = 'H10' THEN 'H3010'
+  WHEN contractor_reference = 'H11' THEN 'H3016'
+  WHEN contractor_reference = 'H12' THEN 'H3004'
+  WHEN contractor_reference = 'H13' THEN 'H3008'
+  WHEN contractor_reference = 'H14' THEN 'H1040'
+  WHEN contractor_reference = 'H15' THEN 'H1039'
+  END AS cost_code,
+  address_line AS address,
+  description_of_work AS comment,
+  closed_date AS closed_at,
+  0 AS value,
+  0 AS duration,
+  0 AS monday,
+  0 AS tuesday,
+  0 AS wednesday,
+  0 AS thursday,
+  0 AS friday,
+  0 AS saturday,
+  0 AS sunday,
+  true AS read_only
+FROM work_order_corrections
+WHERE status_code = 1000 AND is_overtime = true;
+
+-- Insert new out-of-hours pay elements that were completed
+INSERT INTO pay_elements (
+  timesheet_id, pay_element_type_id, work_order, cost_code, address,
+  comment, closed_at, value, duration, monday, tuesday, wednesday,
+  thursday, friday, saturday, sunday, read_only
+)
+SELECT
+  CONCAT(payroll_number, '/', TO_CHAR(DATE_TRUNC('week', closed_date), 'YYYY-MM-DD')) AS timesheet_id,
+  501 AS pay_element_type_id,
+  work_order,
+  CASE
+  WHEN contractor_reference = 'H01' THEN 'H3009'
+  WHEN contractor_reference = 'H02' THEN 'H3007'
+  WHEN contractor_reference = 'H03' THEN 'H3015'
+  WHEN contractor_reference = 'H04' THEN 'H3002'
+  WHEN contractor_reference = 'H05' THEN 'H3002'
+  WHEN contractor_reference = 'H06' THEN 'H3003'
+  WHEN contractor_reference = 'H07' THEN 'H3010'
+  WHEN contractor_reference = 'H08' THEN 'H3002'
+  WHEN contractor_reference = 'H09' THEN 'H3005'
+  WHEN contractor_reference = 'H10' THEN 'H3010'
+  WHEN contractor_reference = 'H11' THEN 'H3016'
+  WHEN contractor_reference = 'H12' THEN 'H3004'
+  WHEN contractor_reference = 'H13' THEN 'H3008'
+  WHEN contractor_reference = 'H14' THEN 'H1040'
+  WHEN contractor_reference = 'H15' THEN 'H1039'
+  END AS cost_code,
+  address_line AS address,
+  description_of_work AS comment,
+  closed_date AS closed_at,
+  ROUND(operative_cost * job_percentage / 100, 4) AS value,
+  0 AS duration,
+  0 AS monday,
+  0 AS tuesday,
+  0 AS wednesday,
+  0 AS thursday,
+  0 AS friday,
+  0 AS saturday,
+  0 AS sunday,
+  true AS read_only
+FROM work_order_corrections
+WHERE status_code = 50 AND is_outofhours = true;
+
+-- Insert new out-of-hours pay elements that were closed as 'No Access'
+INSERT INTO pay_elements (
+  timesheet_id, pay_element_type_id, work_order, cost_code, address,
+  comment, closed_at, value, duration, monday, tuesday, wednesday,
+  thursday, friday, saturday, sunday, read_only
+)
+SELECT
+  CONCAT(payroll_number, '/', TO_CHAR(DATE_TRUNC('week', closed_date), 'YYYY-MM-DD')) AS timesheet_id,
+  501 AS pay_element_type_id,
+  work_order,
+  CASE
+  WHEN contractor_reference = 'H01' THEN 'H3009'
+  WHEN contractor_reference = 'H02' THEN 'H3007'
+  WHEN contractor_reference = 'H03' THEN 'H3015'
+  WHEN contractor_reference = 'H04' THEN 'H3002'
+  WHEN contractor_reference = 'H05' THEN 'H3002'
+  WHEN contractor_reference = 'H06' THEN 'H3003'
+  WHEN contractor_reference = 'H07' THEN 'H3010'
+  WHEN contractor_reference = 'H08' THEN 'H3002'
+  WHEN contractor_reference = 'H09' THEN 'H3005'
+  WHEN contractor_reference = 'H10' THEN 'H3010'
+  WHEN contractor_reference = 'H11' THEN 'H3016'
+  WHEN contractor_reference = 'H12' THEN 'H3004'
+  WHEN contractor_reference = 'H13' THEN 'H3008'
+  WHEN contractor_reference = 'H14' THEN 'H1040'
+  WHEN contractor_reference = 'H15' THEN 'H1039'
+  END AS cost_code,
+  address_line AS address,
+  description_of_work AS comment,
+  closed_date AS closed_at,
+  0 AS value,
+  0 AS duration,
+  0 AS monday,
+  0 AS tuesday,
+  0 AS wednesday,
+  0 AS thursday,
+  0 AS friday,
+  0 AS saturday,
+  0 AS sunday,
+  true AS read_only
+FROM work_order_corrections
+WHERE status_code = 1000 AND is_outofhours = true;
+
+-- Ensure overtime pay elements are at the correct rate
+UPDATE pay_elements SET value = 21.98
+WHERE closed_at >= '2022-03-28' AND pay_element_type_id = 401 AND value = 21.60;
+
+COMMIT;
+
+-- We created the view as temporary so PostgreSQL will clean
+-- it up anyway but we'll drop it here for the sake of completeness
+DROP TABLE work_order_corrections;

--- a/data/migrations/20220422-190000-correct-split-work-orders/export-work-order-corrections.sql
+++ b/data/migrations/20220422-190000-correct-split-work-orders/export-work-order-corrections.sql
@@ -1,0 +1,47 @@
+-- The \COPY command needs to be on one line so we create
+-- a temporary views as our queries are complex
+CREATE TEMPORARY VIEW work_order_corrections AS
+
+-- Dump affected work orders based on those having more than one work_order_operatives record:
+SELECT
+  wo.id AS work_order,
+  wo.status_code,
+  p.contractor_reference,
+  pa.address_line,
+  wo.description_of_work,
+  wo.closed_date,
+  o.payroll_number,
+  woo.job_percentage,
+  SUM(ROUND((rsi.quantity_amount * sc.standard_minute_value)::numeric, 2)) AS total_smv,
+  SUM(ROUND((rsi.quantity_amount * sc.operative_cost)::numeric, 2)) AS operative_cost,
+  bool_or(wo.is_overtime OR (wo.payment_type IS NOT NULL AND wo.payment_type = 1)) AS is_overtime,
+  bool_or(sc.is_outofhours) AS is_outofhours
+FROM work_orders AS wo
+INNER JOIN party AS p ON wo.assigned_to_primary_id = p.id
+INNER JOIN work_order_operatives AS woo ON wo.id = woo.work_order_id
+INNER JOIN property_class AS pc ON wo.site_id = pc.site_id
+INNER JOIN property_address AS pa ON pc.address_id = pa.id
+INNER JOIN work_elements AS we ON wo.id = we.work_order_id
+INNER JOIN rate_schedule_item AS rsi ON we.id = rsi.work_element_id
+INNER JOIN sor_codes AS sc ON rsi.custom_code = sc.code
+INNER JOIN operatives AS o ON woo.operative_id = o.id
+WHERE wo.id IN (
+  SELECT t1.work_order_id
+  FROM work_order_operatives AS t1
+  INNER JOIN work_orders AS t2 ON t1.work_order_id = t2.id
+  WHERE t2.closed_date >= '2022-01-31'
+  AND t2.closed_date < '2022-04-13'
+  AND t2.status_code IN (50, 1000)
+  GROUP BY t1.work_order_id
+  HAVING COUNT(*) > 1
+)
+AND o.payroll_number ~ '^\d{6}$' AND o.name !~ '\(SVY\)'
+GROUP BY wo.id, wo.status_code, p.contractor_reference, pa.address_line, wo.description_of_work, wo.closed_date, o.payroll_number, woo.job_percentage
+ORDER BY wo.id;
+
+-- Export query results to a CSV file
+\COPY (SELECT * FROM work_order_corrections) TO 'work_order_corrections.csv' CSV HEADER;
+
+-- We created the view as temporary so PostgreSQL will clean
+-- it up anyway but we'll drop it here for the sake of completeness
+DROP VIEW work_order_corrections;


### PR DESCRIPTION
Due to a race condition in the DRS sync some errors were introduced in the bonus calculation for affected work orders. This database removes the existing pay elements for the the affected work orders and creates new ones based on the corrected data from Repairs Hub.