### PR TITLE
Auto-confirm installation of packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,10 +98,10 @@ commands:
       - setup_remote_docker
       - run:
           name: Install SSH client
-          command: apt-get update && apt-get install openssh-client
+          command: apt-get update && apt-get install -y openssh-client
       - run:
           name: Install Unzip
-          command: apt-get update && apt-get install unzip
+          command: apt-get update && apt-get install -y unzip
       - run:
           name: Install AWS CLI
           command: |


### PR DESCRIPTION
For some reason unzip didn't need it but openssh-client does.
