### PR TITLE
Use the current salary band when approving fixed band operatives

### DIFF
--- a/BonusCalcApi/V1/UseCase/SupervisorBandDecisionUseCase.cs
+++ b/BonusCalcApi/V1/UseCase/SupervisorBandDecisionUseCase.cs
@@ -52,7 +52,14 @@ namespace BonusCalcApi.V1.UseCase
 
             if (request.Decision == BandChangeDecision.Approved)
             {
-                bandChange.FinalBand = bandChange.ProjectedBand;
+                if (bandChange.FixedBand)
+                {
+                    bandChange.FinalBand = bandChange.SalaryBand;
+                }
+                else
+                {
+                    bandChange.FinalBand = bandChange.ProjectedBand;
+                }
             }
             else
             {


### PR DESCRIPTION
For the closing of the 2022/2 period the frontend submitted the correct salary band but for reasons of security the backend ignores the submitted salary band when processing approvals from supervisors. Given that the projected band of fixed band operatives is lower than their actual band then this resulted in quite a few operatives having their salary band lowered. This error has been corrected in the production database and this change will prevent it from happening again.
