### PR TITLE
Sync minor version - postgres

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -65,7 +65,7 @@ module "database" {
   db_port = local.db_port
   subnet_ids = data.aws_subnet_ids.private_subnets.ids
   db_engine = "postgres"
-  db_engine_version = "12.11"
+  db_engine_version = "12.14"
   db_instance_class = "db.t3.small"
   db_allocated_storage = 20
   maintenance_window = "sun:04:00-sun:04:30"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -65,7 +65,7 @@ module "database" {
   db_port = local.db_port
   subnet_ids = data.aws_subnet_ids.private_subnets.ids
   db_engine = "postgres"
-  db_engine_version = "12.11"
+  db_engine_version = "12.14"
   db_instance_class = "db.t3.micro"
   db_allocated_storage = 20
   maintenance_window = "sun:04:00-sun:04:30"


### PR DESCRIPTION
- BonusCalc uses a Postgres (RDS) DB to store data
- This is set to automatically update minor versions (AWS does this automatically)
- This leads to a mismatch in the terraform schema over time

So, sync the TF schema with today's reality