### PR TITLE
Terraform friendly pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ jobs:
           stage: "production"
 
 workflows:
-  check-development:
+  feature-branch-checks:
     jobs:
       - check-code-formatting
       - build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,23 +305,29 @@ workflows:
           filters:
             branches:
               only: master
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: master
       - assume-role-production:
           context: api-assume-role-housing-production-context
           requires:
-              - permit-production-terraform-release
+              - deploy-to-staging
           filters:
              branches:
                only: master
-      - terraform-init-and-apply-to-production:
+      - preview-terraform-production:
           requires:
             - assume-role-production
+          filters:
+            branches:
+              only: master
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - preview-terraform-production
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-production:
+          requires:
+            - permit-production-terraform-release
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,12 @@ workflows:
   check-development:
     jobs:
       - check-code-formatting
-      - build-and-test
+      - build-and-test:
+          requires:
+            - check-code-formatting
+          filters:
+            branches:
+              ignore: master
       - assume-role-staging:
           context:
             - api-assume-role-housing-staging-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,13 +269,26 @@ workflows:
           context:
             - api-assume-role-housing-staging-context
           requires:
-              - build-and-test
+            - build-and-test
           filters:
-             branches:
-               only: master
-      - terraform-init-and-apply-to-staging:
+            branches:
+              only: master
+      - preview-terraform-staging:
           requires:
             - assume-role-staging
+          filters:
+            branches:
+              only: master
+      - permit-staging-terraform-release:
+          type: approval
+          requires:
+            - preview-terraform-staging
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-staging:
+          requires:
+            - permit-staging-terraform-release
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,16 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
+  preview-terraform-staging:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "staging"
+  preview-terraform-production:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "production"
   terraform-init-and-apply-to-staging:
     executor: docker-terraform
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,22 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  preview-terraform:
+    description: "Previews terraform state changes"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: get, init, and plan
+
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,6 +296,9 @@ workflows:
           type: approval
           requires:
             - deploy-to-staging
+          filters:
+            branches:
+              only: master
       - assume-role-production:
           context: api-assume-role-housing-production-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,29 @@ workflows:
     jobs:
       - check-code-formatting
       - build-and-test
+      - assume-role-staging:
+          context:
+            - api-assume-role-housing-staging-context
+          filters:
+            branches:
+              ignore: master
+      - preview-terraform-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              ignore: master
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore: master
+      - preview-terraform-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              ignore: master
   check-and-deploy-staging-and-production:
       jobs:
       - build-and-test:


### PR DESCRIPTION
# What:
- Added Terraform staging & production state preview to the CCI feature branch workflow.
- Added a Safeguard to prevent staging terraform from applying automatically.
- Added additional Terraform state previews for the `master` branch workflow.
- Renamed the `'any branch'` workflow from `check-development` to `feature-branch-checks`.
- Added the `permit-production-terraform-release` step's missing `master` branch filter.

# Why:
- We want to know the impact of our Terraform file changes before we merge those changes to the main branch.
- We don't want to staging terraform to apply automatically because occasionally resource's state gets tweaked through the AWS Web UI console, which causes Terraform drift. If left unchanged, Terraform's automatic staging apply would undo any staging environment changes done via AWS Web UI console upon any CCI pipeline run regardless of whether it tweaked infrastructure, or added an API endpoint. We want the decision of whether to undo manual AWS resource state changes to fall on the developer that caused the pipeline to trigger.
- The additional terraform previews are to prevent the issue described in the bullet-point above. It may seem redundant that we have a preview within `feature` branch, we merge, and then a preview on `master`. However, let's not forget that within Hackney we sometimes to tend a while until we merge Pull Request, and sometimes a while until we permit the deployments. As such, with enough time, the preview logs were generated on `feature` may become stale and will no longer represent the actual Terraform state (and won't catch its drift) by the time Pull Request actually gets merged due to the possibility of those: AWS Web UI tweaks, or even Cloud Engineering team running some update scripts to the same resources, or if the base module consumed by the app's local terraform receives changes, etc.
- Branch rename was made to avoid confusion about the existence of the `development` environment. The `develop` branch is heavily out of sync, and the pipeline steps have long been [removed](https://github.com/LBHackney-IT/bonuscalc-api/commit/d9629988d2c1dcb0e4e3126395da3cdad9818596).
- Added missing branch filter for one of the prod permit steps. It doesn't change any behaviour as that step depends on other workflow steps that do have the filter, however, it's better to stay explicit  to avoid ambiguity of why that one filter is missing.

# Notes:
- The new terraform workflow within the `master` workflow expects minimal time difference between the push to the branch and between the terraform apply steps.
- This is a consequence of assume role being done before the permit step. If enough time passes between the `assume role + TF preview`, and `permit TF deployment`, then the temporary AWS credentials will expire and will prevent the TF deployment.
- While this may seem like an issue or a bug within a pipeline, **it is not!** It would be easy to add another assume role after the permit, but **do not!** This behaviour is actually a feature that prevents doing the `permit terraform deployment` based on stale `preview` _(terraform plan)_ step information! If you want get a credentials issue due to temporary credentials having expired, then **just re-run the pipeline**.