### PR TITLE
Removed stale CODEOWNERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @Asura5 @LBHCallumM @ange47rm


### PR DESCRIPTION
# What:
- Removed stale CODEOWNERS file.

# Why:
- Not a single person who built the application is around anymore. So the CODEOWNERS doesn't have the purpose anymore due to there being no one who'd review the changes from the perspective of in-depth working and/or business knowledge of the repository.
