### PR TITLE
Resolve `staging` Terraform Drift for database engine version.

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -65,7 +65,7 @@ module "database" {
   db_port = local.db_port
   subnet_ids = data.aws_subnet_ids.private_subnets.ids
   db_engine = "postgres"
-  db_engine_version = "12.14"
+  db_engine_version = "12.17"
   db_instance_class = "db.t3.micro"
   db_allocated_storage = 20
   maintenance_window = "sun:04:00-sun:04:30"


### PR DESCRIPTION
# What:
- Change staging database `db_engine_version` from "12.14" to "12.17".

# Why:
- To match the database engine version that's on the cloud.
- Also to trigger the SSL Certificate update done on the **aws-hackney-common-terraform** PR [#68](https://github.com/LBHackney-IT/aws-hackney-common-terraform/pull/68).

# Notes:
- This change **will also trigger the SSL CA Certificate update** from `rds-ca-2019` to `rds-ca-rsa2048-g1`.

# Co-authored:
Co-authored-by: @Miles-Alford
Co-authored-by: Miles Alford <43789512+Miles-Alford@users.noreply.github.com>