### PR TITLE
Resolve `production` terraform drift + trigger SSL upgrade (knock-on effect)

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -75,4 +75,7 @@ module "database" {
   multi_az = local.environment == "production"
   publicly_accessible = false
   project_name = "bonus calc"
+  additional_tags = {
+    BackupPolicy = "Prod"
+  }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -65,7 +65,7 @@ module "database" {
   db_port = local.db_port
   subnet_ids = data.aws_subnet_ids.private_subnets.ids
   db_engine = "postgres"
-  db_engine_version = "12.14"
+  db_engine_version = "12.17"
   db_instance_class = "db.t3.small"
   db_allocated_storage = 20
   maintenance_window = "sun:04:00-sun:04:30"


### PR DESCRIPTION
# What:
 - Resolve `production` postgresql database engine version terraform drift.
 - Add missing `BackupPolicy` tag to the `production` postgresql database module resource.

# Why:
 - To prevent these from being downgraded/removed whilst re-running TF pipeline to apply the SSL changes _(see notes)_.
 - Did these changes primarily to trigger the SSL Certificate update done on the **aws-hackney-common-terraform** PR [#68](https://github.com/LBHackney-IT/aws-hackney-common-terraform/pull/68).

# Notes:
- This change **will trigger the SSL CA Certificate update** from `rds-ca-2019` to `rds-ca-rsa2048-g1`.
- The staging database SSL update was trigger by the PR prior: #113 .
- The development database is not Terraform managed & **[there's no development environment](https://github.com/LBHackney-IT/bonuscalc-api/commit/d9629988d2c1dcb0e4e3126395da3cdad9818596)**. We've requested CE team to stop it for a week to see whether anyone complains about it being missing.

# Screenshots:

| TF plan for production postgres database _(same diff as staging)_ |
| ---- |
| ![image](https://github.com/user-attachments/assets/63b292d1-9c4b-42bf-890d-56128365e687) |