### PR TITLE
Upgrade `staging` bonus-calc postgres database engine version to v16.

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -67,6 +67,7 @@ module "database" {
   db_engine = "postgres"
   db_engine_version = "16.1"
   db_parameter_group_name = "postgres16"
+  db_allow_major_version_upgrade = true
   db_instance_class = "db.t3.micro"
   db_allocated_storage = 20
   maintenance_window = "sun:04:00-sun:04:30"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -66,6 +66,7 @@ module "database" {
   subnet_ids = data.aws_subnet_ids.private_subnets.ids
   db_engine = "postgres"
   db_engine_version = "16.1"
+  db_parameter_group_name = "postgres16"
   db_instance_class = "db.t3.micro"
   db_allocated_storage = 20
   maintenance_window = "sun:04:00-sun:04:30"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -65,7 +65,7 @@ module "database" {
   db_port = local.db_port
   subnet_ids = data.aws_subnet_ids.private_subnets.ids
   db_engine = "postgres"
-  db_engine_version = "12.17"
+  db_engine_version = "16.1"
   db_instance_class = "db.t3.micro"
   db_allocated_storage = 20
   maintenance_window = "sun:04:00-sun:04:30"


### PR DESCRIPTION
# What:
 - Upgrade `staging` bonus-calc postgres database engine version from v12.17 to v16.1.
 - Attached a non-default parameter group.

# Why:
 - To save costs by moving away from extended support versions.
 - The default postgres 16 parameter group forces ssl for which we're not prepared yet.

# Notes:
 - The custom 'postgres16' parameter group is going to be shared by all the databases within the `Housing-Staging` AWS account. So it was created manually due to there being no repository for placing shared housing configuration.  