### PR TITLE
Fix `staging` Terraform drift

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
           command: ./dotnet-format-local/dotnet-format --check
   build-and-test:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:2024.11.1
       docker_layer_caching: true
     steps:
       - checkout

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -65,7 +65,7 @@ module "database" {
   db_port = local.db_port
   subnet_ids = data.aws_subnet_ids.private_subnets.ids
   db_engine = "postgres"
-  db_engine_version = "16.1"
+  db_engine_version = "16.3"
   db_parameter_group_name = "postgres16"
   db_allow_major_version_upgrade = true
   db_instance_class = "db.t3.micro"
@@ -77,4 +77,7 @@ module "database" {
   multi_az = local.environment == "production"
   publicly_accessible = false
   project_name = "bonus calc"
+  additional_tags = {
+    BackupPolicy = "Prod"
+  }
 }


### PR DESCRIPTION
# What
This PR introduces two changes. The first is updating the DB module for staging to match what is on the AWS account thus fixing its drift. The second is updating the ubuntu image on the `build-and-test` job from `2021-04-01` to `2024-11-1` which is the latest image.
# Why
To fix the Terraform drift for the DB on the staging environment due to its re-encryption and to ensure the pipeline can run the `build-and-test` job by updating its ubuntu image to a non-deprecated one.