### PR TITLE
Add Makefile for database connection and port forwarding setup

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,4 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
+# This file specifies owners for pull request approval
+# See https://help.github.com/articles/about-code-owners/
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty
+* @LBHackney-IT/housing-products

--- a/database/Makefile
+++ b/database/Makefile
@@ -1,0 +1,51 @@
+.ONESHELL:
+# Requires AWS CLI Profile matching housing-${ENVIRONMENT} to be set up
+# Requires AWS Session Manager Plugin to be installed:
+#     https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+# On Windows you will need to run these commands using Git Bash, NOT Powershell / CMD
+
+
+# -- Configuration --
+# Set the local port to use for the port forwarding - connect to this port on your local machine to connect to the RDS
+LOCAL_PORT = 5432
+# For Parameter store URL Paths
+STAGE := staging
+# Set to AWSCLI Profile name
+PROFILE := "housing-${STAGE}"
+
+# -- Parameter Store paths --
+JUMP_BOX_INSTANCE_NAME_PATH:="platform-apis-jump-box-instance-name"
+POSTGRES_HOST_PATH:=" /bonuscalc-api/${STAGE}/postgres-hostname"
+POSTGRES_PORT_PATH:=" /bonuscalc-api/${STAGE}/postgres-port"
+POSTGRES_DATABASE_PATH:=" /bonuscalc-api/${STAGE}/postgres-database"
+POSTGRES_USERNAME_PATH:=" /bonuscalc-api/${STAGE}/postgres-username"
+POSTGRES_PASSWORD_PATH:=" /bonuscalc-api/${STAGE}/postgres-password"
+
+# -- Parameters --
+# Get parameters from parameter store for the profile used
+_ := $(shell aws sts get-caller-identity --profile ${PROFILE} || aws sso login --profile ${PROFILE})
+INSTANCE_ID := $(shell aws ssm get-parameter --name ${JUMP_BOX_INSTANCE_NAME_PATH} --region "eu-west-2" --profile ${PROFILE} --query Parameter.Value --output text)
+REMOTE_HOST := $(shell aws ssm get-parameter --name ${POSTGRES_HOST_PATH} --region "eu-west-2" --profile ${PROFILE} --query Parameter.Value --output text)
+REMOTE_PORT := $(shell aws ssm get-parameter --name ${POSTGRES_PORT_PATH} --region "eu-west-2" --profile ${PROFILE} --query Parameter.Value --output text)
+REMOTE_DATABASE := $(shell aws ssm get-parameter --name ${POSTGRES_DATABASE_PATH} --region "eu-west-2" --profile ${PROFILE} --query Parameter.Value --output text)
+REMOTE_USERNAME := $(shell aws ssm get-parameter --name ${POSTGRES_USERNAME_PATH} --region "eu-west-2" --profile ${PROFILE} --query Parameter.Value --output text)
+REMOTE_PASSWORD := $(shell aws ssm get-parameter --with-decryption --name ${POSTGRES_PASSWORD_PATH} --region "eu-west-2" --profile ${PROFILE} --query Parameter.Value --output text)
+
+DATABASE_PARAMS = '{"host":["${REMOTE_HOST}"], "portNumber":["${REMOTE_PORT}"], "localPortNumber":["${LOCAL_PORT}"]}'
+
+# -- Commands --
+
+# Use this command to connect to create a port forwarding session from localhost to the RDS instance via the jump-box
+# This will allow connecting to the database using a GUI tool like pgAdmin, or with local scripts
+port_forwarding_to_bonuscalc_db:
+	echo Connect to Postgres at localhost:${LOCAL_PORT}
+	echo USERNAME: ${REMOTE_USERNAME}
+	echo PASSWORD: ${REMOTE_PASSWORD}
+	echo DATABASE: ${REMOTE_DATABASE}
+
+	aws ssm start-session \
+		--target ${INSTANCE_ID} \
+		--region eu-west-2 \
+		--profile ${PROFILE} \
+		--document-name AWS-StartPortForwardingSessionToRemoteHost \
+		--parameters ${DATABASE_PARAMS};


### PR DESCRIPTION
Introduce a Makefile to streamline the setup of database connections and port forwarding using AWS CLI and SSM. This facilitates easier access to the RDS instance through the jump box.